### PR TITLE
Exit code argument for showHelp

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,9 +26,9 @@ module.exports = function (opts, minimistOpts) {
 	var pkg = typeof opts.pkg === 'string' ? require(path.join(parentDir, opts.pkg)) : opts.pkg;
 	var argv = minimist(opts.argv, minimistOpts);
 	var help = '\n' + indentString(pkg.description + (opts.help ? '\n\n' + opts.help : '\n'), '  ');
-	var showHelp = function () {
+	var showHelp = function (code) {
 		console.log(help);
-		process.exit();
+		process.exit(code || 0);
 	};
 
 	if (argv.version && opts.version !== false) {

--- a/readme.md
+++ b/readme.md
@@ -60,7 +60,7 @@ Returns an object with:
 - `flags` *(object)* - Flags converted to camelCase
 - `pkg` *(object)* - The `package.json` object
 - `help` *(object)* - The help text used with `--help`
-- `showHelp()` *(function)* - Show the help text and exit
+- `showHelp([code=0])` *(function)* - Show the help text and exit with `code`
 
 #### options
 


### PR DESCRIPTION
Printing usage text in response to `--help` argument is a normal execution but showing help and terminating the app for other reasons is often not.

For example, on my system `sed --help` shows help for `sed` and exits with code 0, but `sed -x` prints

```
sed: invalid option -- 'x'
```

followed by (mostly) the same usage text and exits with non-zero code 4. However, there is currently no way to implement this behavior using meow's `showHelp` method.