### PR TITLE
Add shortcut for resolving relative paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,6 +52,10 @@ module.exports = function (opts, minimistOpts) {
 		process.exit(code || 0);
 	};
 
+	var cwd = function (filename) {
+		return path.resolve(process.cwd(), filename || '');
+	};
+
 	if (argv.version && opts.version !== false) {
 		console.log(typeof opts.version === 'string' ? opts.version : pkg.version);
 		process.exit();
@@ -68,6 +72,7 @@ module.exports = function (opts, minimistOpts) {
 		input: _,
 		flags: camelcaseKeys(argv),
 		pkg: pkg,
+		cwd: cwd,
 		help: help,
 		showHelp: showHelp
 	};

--- a/readme.md
+++ b/readme.md
@@ -11,6 +11,7 @@
 - Converts flags to [camelCase](https://github.com/sindresorhus/camelcase)
 - Outputs version when `--version`
 - Outputs description and supplied help text when `--help`
+- Resolves relative filenames
 - Makes unhandled rejected promises [fail loudly](https://github.com/sindresorhus/loud-rejection) instead of the default silent fail
 - Sets the process title to the binary name defined in package.json
 
@@ -70,6 +71,7 @@ Returns an object with:
 - `input` *(array)* - Non-flag arguments
 - `flags` *(object)* - Flags converted to camelCase
 - `pkg` *(object)* - The `package.json` object
+- `cwd([file=''])` *(function)* - Resolves relative path to an absolute path
 - `help` *(object)* - The help text used with `--help`
 - `showHelp([code=0])` *(function)* - Show the help text and exit with `code`
 

--- a/test.js
+++ b/test.js
@@ -1,6 +1,7 @@
 import childProcess from 'child_process';
 import test from 'ava';
 import indentString from 'indent-string';
+import path from 'path';
 import fn from './';
 
 test('return object', t => {
@@ -61,6 +62,15 @@ test('spawn cli and test input', t => {
 		t.ifError(err);
 		t.is(stdout, 'u\nunicorn\nmeow\n');
 	});
+});
+
+test('return cwd', t => {
+	const cli = fn();
+	const cwd = cli.cwd('index.js');
+	t.true(path.isAbsolute(cwd));
+	t.is(path.dirname(cwd), process.cwd());
+	t.is(path.basename(cwd), 'index.js');
+	t.end();
 });
 
 test.serial('pkg.bin as a string should work', t => {


### PR DESCRIPTION
I like meow and want to make it better.

In my own cli apps I often write `cwd`-method that resolves relative filenames and current working dir. So, I propose to add this feature into **meow**.

I've already written tests and desc for `cwd`-method, so please check my changes and merge if it'll be useful for everyone.