### PR TITLE
add type inference option

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,8 +25,13 @@ module.exports = function (opts, minimistOpts) {
 			cwd: parentDir,
 			normalize: false
 		}).pkg,
-		argv: process.argv.slice(2)
+		argv: process.argv.slice(2),
+		inferType: false
 	}, opts);
+
+	if (opts.inferType === false) {
+		minimistOpts = objectAssign(minimistOpts || {}, {string: ['_']});
+	}
 
 	if (Array.isArray(opts.help)) {
 		opts.help = opts.help.join('\n');

--- a/index.js
+++ b/index.js
@@ -31,8 +31,12 @@ module.exports = function (opts, minimistOpts) {
 
 	minimistOpts = objectAssign({string: ['_']}, minimistOpts);
 
-	if (opts.inferType === false && minimistOpts.string.indexOf('_') === -1) {
+	var index = minimistOpts.string.indexOf('_');
+
+	if (opts.inferType === false && index === -1) {
 		minimistOpts.string.push('_');
+	} else if (opts.inferType === true && index !== -1) {
+		minimistOpts.string.splice(index, 1);
 	}
 
 	if (Array.isArray(opts.help)) {

--- a/index.js
+++ b/index.js
@@ -29,8 +29,10 @@ module.exports = function (opts, minimistOpts) {
 		inferType: false
 	}, opts);
 
-	if (opts.inferType === false) {
-		minimistOpts = objectAssign(minimistOpts || {}, {string: ['_']});
+	minimistOpts = objectAssign({string: ['_']}, minimistOpts);
+
+	if (opts.inferType === false && minimistOpts.string.indexOf('_') === -1) {
+		minimistOpts.string.push('_');
 	}
 
 	if (Array.isArray(opts.help)) {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,13 @@
   },
   "devDependencies": {
     "ava": "*",
+    "execa": "^0.1.1",
     "indent-string": "^2.1.0",
     "xo": "*"
+  },
+  "xo": {
+    "ignores": [
+      "test.js"
+    ]
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -131,7 +131,15 @@ Custom arguments object.
 Type: `boolean`  
 Default: `false`
 
-Set it to `true` to enable type inference.
+Set it to `true` to enable argument type inference.
+
+###### example
+
+```
+$ ./foo-app.js 5
+```
+
+By default, the argument with value `5` is a string. When using type inference, the argument will be parsed to a number.
 
 #### minimistOptions
 

--- a/readme.md
+++ b/readme.md
@@ -126,6 +126,13 @@ Default: `process.argv.slice(2)`
 
 Custom arguments object.
 
+##### inferType
+
+Type: `boolean`  
+Default: `false`
+
+Set it to `true` to enable type inference.
+
 #### minimistOptions
 
 Type: `object`  

--- a/test.js
+++ b/test.js
@@ -65,6 +65,10 @@ test('single character flag casing should be preserved', t => {
 	t.ok(fn({argv: ['-F']}).flags.F);
 });
 
-test('should not infer type', t => {
+test('type inference', t => {
 	t.is(fn({argv: ['5']}).input[0], '5');
+	t.is(fn({argv: ['5']}, {string: ['_']}).input[0], '5');
+	t.is(fn({argv: ['5'], inferType: true}).input[0], 5);
+	t.is(fn({argv: ['5'], inferType: true}, {string: ['foo']}).input[0], 5);
+	t.is(fn({argv: ['5'], inferType: true}, {string: ['_', 'foo']}).input[0], 5);
 });

--- a/test.js
+++ b/test.js
@@ -2,8 +2,10 @@ import childProcess from 'child_process';
 import test from 'ava';
 import indentString from 'indent-string';
 import execa from 'execa';
-import {version as pkgVersion} from './package.json';
+import pkg from './package.json';
 import fn from './';
+
+global.Promise = Promise;
 
 test('return object', t => {
 	const cli = fn({
@@ -31,19 +33,19 @@ test('support help shortcut', t => {
 });
 
 test('spawn cli and show version', async t => {
-	const {stdout} = await execa('./fixture.js', ['--version'], {cwd: __dirname});
+	const {stdout} = await execa('./fixture.js', ['--version']);
 
-	t.is(stdout, pkgVersion);
+	t.is(stdout, pkg.version);
 });
 
 test('spawn cli and show help screen', async t => {
-	const {stdout} = await execa('./fixture.js', ['--help'], {cwd: __dirname});
+	const {stdout} = await execa('./fixture.js', ['--help']);
 
 	t.is(stdout, indentString('\nCustom description\n\nUsage\n  foo <input>', '  '));
 });
 
 test('spawn cli and test input', async t => {
-	const {stdout} = await execa('./fixture.js', ['-u', 'cat'], {cwd: __dirname});
+	const {stdout} = await execa('./fixture.js', ['-u', 'cat']);
 
 	t.is(stdout, 'u\nunicorn\nmeow');
 });
@@ -64,7 +66,5 @@ test('single character flag casing should be preserved', t => {
 });
 
 test('should not infer type', t => {
-	console.log(fn({argv: ['5']}).input);
-
 	t.is(fn({argv: ['5']}).input[0], '5');
 });


### PR DESCRIPTION
Adds the option `inferType` to the options object. It's `false` by default which means that command line arguments are not parsed. (fixes #17)

Also fixed tests with latest AVA.