### PR TITLE
decamilize minimist defaults.

### DIFF
--- a/fixture.js
+++ b/fixture.js
@@ -10,9 +10,14 @@ var cli = meow({
 	]
 }, {
 	alias: {u: 'unicorn'},
-	default: {meow: 'dog'}
+	default: {meow: 'dog', camelCaseOption: 'foo'}
 });
 
-Object.keys(cli.flags).forEach(function (el) {
-	console.log(el);
-});
+if (cli.flags.camelCaseOption !== 'foo') {
+	console.log(cli.flags.camelCaseOption)
+} else {
+	Object.keys(cli.flags).forEach(function (el) {
+		console.log(el);
+	});
+}
+

--- a/index.js
+++ b/index.js
@@ -3,6 +3,8 @@ var path = require('path');
 var minimist = require('minimist');
 var objectAssign = require('object-assign');
 var camelcaseKeys = require('camelcase-keys');
+var decamelize = require('decamelize');
+var mapObj = require('map-obj');
 var trimNewlines = require('trim-newlines');
 var redent = require('redent');
 var readPkgUp = require('read-pkg-up');
@@ -30,6 +32,10 @@ module.exports = function (opts, minimistOpts) {
 	}, opts);
 
 	minimistOpts = objectAssign({string: ['_']}, minimistOpts);
+
+	minimistOpts.default = mapObj(minimistOpts.default || {}, function (key, value) {
+		return [decamelize(key, '-'), value];
+	});
 
 	var index = minimistOpts.string.indexOf('_');
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,9 @@
   ],
   "dependencies": {
     "camelcase-keys": "^2.0.0",
+    "decamelize": "^1.1.2",
     "loud-rejection": "^1.0.0",
+    "map-obj": "^1.0.1",
     "minimist": "^1.1.3",
     "normalize-package-data": "^2.3.4",
     "object-assign": "^4.0.1",

--- a/test.js
+++ b/test.js
@@ -46,7 +46,13 @@ test('spawn cli and show help screen', async t => {
 test('spawn cli and test input', async t => {
 	const {stdout} = await execa('./fixture.js', ['-u', 'cat']);
 
-	t.is(stdout, 'u\nunicorn\nmeow');
+	t.is(stdout, 'u\nunicorn\nmeow\ncamelCaseOption');
+});
+
+test('spawn cli and test input', async t => {
+	const {stdout} = await execa('./fixture.js', ['--camel-case-option', 'bar']);
+
+	t.is(stdout, 'bar');
 });
 
 test.serial('pkg.bin as a string should work', t => {


### PR DESCRIPTION
Currently, it's a bit awkward specifying the minimist defaults as minimist expects decamilized flag names, but we camelize the output. This decamilizes minimistOptions.default so there is symmetry on the input and output.

Reference: https://github.com/sindresorhus/ava/pull/407#discussion_r48722853