### PR TITLE
Decamelize keys with decamelize-keys

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,8 +3,7 @@ var path = require('path');
 var minimist = require('minimist');
 var objectAssign = require('object-assign');
 var camelcaseKeys = require('camelcase-keys');
-var decamelize = require('decamelize');
-var mapObj = require('map-obj');
+var decamelizeKeys = require('decamelize-keys');
 var trimNewlines = require('trim-newlines');
 var redent = require('redent');
 var readPkgUp = require('read-pkg-up');
@@ -33,9 +32,7 @@ module.exports = function (opts, minimistOpts) {
 
 	minimistOpts = objectAssign({string: ['_']}, minimistOpts);
 
-	minimistOpts.default = mapObj(minimistOpts.default || {}, function (key, value) {
-		return [decamelize(key, '-'), value];
-	});
+	minimistOpts.default = decamelizeKeys(minimistOpts.default || {}, '-');
 
 	var index = minimistOpts.string.indexOf('_');
 

--- a/package.json
+++ b/package.json
@@ -39,9 +39,8 @@
   ],
   "dependencies": {
     "camelcase-keys": "^2.0.0",
-    "decamelize": "^1.1.2",
+    "decamelize-keys": "^1.0.0",
     "loud-rejection": "^1.0.0",
-    "map-obj": "^1.0.1",
     "minimist": "^1.1.3",
     "normalize-package-data": "^2.3.4",
     "object-assign": "^4.0.1",


### PR DESCRIPTION
I forked `camelсase-keys` to create [`decamelize-keys`](https://github.com/dsblv/decamelize-keys) a while back. The PR is about using it.

No big deal, just to make the code look cleaner.