### PR TITLE
Fix "rainbow-cake" command in usage example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -25,7 +25,7 @@ $ npm install --save meow
 ## Usage
 
 ```
-$ ./foo-app.js unicorns --rainbow-cake
+$ ./foo-app.js unicorns --rainbow
 ```
 
 ```js


### PR DESCRIPTION
The JS snippet below the command doesn't have the `-cake` part, it's confusing.