### PR TITLE
Skip camelcasing `--` option

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,7 +83,7 @@ module.exports = function (opts, minimistOpts) {
 
 	return {
 		input: _,
-		flags: camelcaseKeys(argv),
+		flags: camelcaseKeys(argv, {exclude: ['--']}),
 		pkg: pkg,
 		help: help,
 		showHelp: showHelp

--- a/test.js
+++ b/test.js
@@ -51,7 +51,7 @@ test('spawn cli and test input', async t => {
 	t.is(stdout, 'u\nunicorn\nmeow\ncamelCaseOption');
 });
 
-test('spawn cli and test input', async t => {
+test('spawn cli and test input flag', async t => {
 	const {stdout} = await execa('./fixture.js', ['--camel-case-option', 'bar']);
 
 	t.is(stdout, 'bar');

--- a/test.js
+++ b/test.js
@@ -8,20 +8,22 @@ global.Promise = Promise;
 
 test('return object', t => {
 	const cli = fn({
-		argv: ['foo', '--foo-bar', '-u', 'cat'],
+		argv: ['foo', '--foo-bar', '-u', 'cat', '--', 'unicorn', 'cake'],
 		help: [
 			'Usage',
 			'  foo <input>'
 		]
 	}, {
-		alias: {u: 'unicorn'},
-		default: {meow: 'dog'}
+		'alias': {u: 'unicorn'},
+		'default': {meow: 'dog'},
+		'--': true
 	});
 
 	t.is(cli.input[0], 'foo');
 	t.true(cli.flags.fooBar);
 	t.is(cli.flags.meow, 'dog');
 	t.is(cli.flags.unicorn, 'cat');
+	t.deepEqual(cli.flags['--'], ['unicorn', 'cake']);
 	t.is(cli.pkg.name, 'meow');
 	t.is(cli.help, indentString('\nCLI app helper\n\nUsage\n  foo <input>\n', '  '));
 });


### PR DESCRIPTION
Since `minimist` accepts a `--` option we should probably not camelcase it since it'll remove it altogether as noted in #33.    