### PR TITLE
Disable the xo/no-process-exit rule for sanity

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,5 +53,10 @@
     "execa": "^0.1.1",
     "indent-string": "^2.1.0",
     "xo": "*"
+  },
+  "xo": {
+    "rules": {
+      "xo/no-process-exit": "off"
+    }
   }
 }


### PR DESCRIPTION
I'm not getting hugged without that rule being disabled:

```
  > xo && ava

  index.js:66:3
  ✖  66:3  Only use process.exit() in CLI apps. Instead, throw an error.  xo/no-process-exit
  ✖  71:3  Only use process.exit() in CLI apps. Instead, throw an error.  xo/no-process-exit
```