### PR TITLE
Default to exit code 2 on help message

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ module.exports = (opts, minimistOpts) => {
 
 	const showHelp = code => {
 		console.log(help);
-		process.exit(code || 0);
+		process.exit(code || 2);
 	};
 
 	if (argv.version && opts.version !== false) {


### PR DESCRIPTION
When a command fails because it's misused and shows the help message instead of executing normally, it should *never* fail with exit code 0 as that will improperly foul things up if the command is executed in an automated way (i.e. a script or `make`).

The convention is code 2, which means "misuse".