### PR TITLE
Update dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,11 +58,13 @@ module.exports = (opts, minimistOpts) => {
 
 	const showHelp = code => {
 		console.log(help);
+		// eslint-disable-next-line unicorn/no-process-exit
 		process.exit(typeof code === 'number' ? code : 2);
 	};
 
 	if (argv.version && opts.version !== false) {
 		console.log(typeof opts.version === 'string' ? opts.version : pkg.version);
+		// eslint-disable-next-line unicorn/no-process-exit
 		process.exit();
 	}
 

--- a/package.json
+++ b/package.json
@@ -38,18 +38,18 @@
     "console"
   ],
   "dependencies": {
-    "camelcase-keys": "^3.0.0",
+    "camelcase-keys": "^4.0.0",
     "decamelize-keys": "^1.0.0",
     "loud-rejection": "^1.0.0",
     "minimist": "^1.1.3",
     "normalize-package-data": "^2.3.4",
-    "read-pkg-up": "^1.0.1",
+    "read-pkg-up": "^2.0.0",
     "redent": "^2.0.0",
     "trim-newlines": "^1.0.0"
   },
   "devDependencies": {
     "ava": "*",
-    "execa": "^0.4.0",
+    "execa": "^0.5.0",
     "indent-string": "^3.0.0",
     "xo": "*"
   },

--- a/test.js
+++ b/test.js
@@ -14,8 +14,8 @@ test('return object', t => {
 			  foo <input>
 		`
 	}, {
-		'alias': {u: 'unicorn'},
-		'default': {meow: 'dog'},
+		alias: {u: 'unicorn'},
+		default: {meow: 'dog'},
 		'--': true
 	});
 


### PR DESCRIPTION
AFAICT all majors are just dropping support for node < 4, which this module has already done.

This change would make stuff dedupe better for us 😄 

Tests pass, but linting fails. I don't think that's my fault? `xo --version` gives `0.17.0`
