### PR TITLE
chore: add typescript typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,26 @@
+/// <reference types="minimist" />
+import * as minimist from 'minimist';
+
+declare function meow(options: string | string[] | meow.Options, minimistOptions?: minimist.Opts): meow.Result;
+declare namespace meow {
+
+	export interface Options {
+		description?: string|boolean;
+		help?: string|boolean;
+		version?: string|boolean;
+		pkg?: any;
+		argv?: string[];
+		inferType?: boolean;
+	}
+
+	export interface Result {
+		input: string[];
+		flags: {[name: string]: any};
+		pkg: any;
+		help: string;
+		showHelp(code: number): void;
+	}
+
+}
+
+export = meow;

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "trim-newlines": "^1.0.0"
   },
   "devDependencies": {
+    "@types/minimist": "^1.1.29",
     "ava": "*",
     "execa": "^0.5.0",
     "indent-string": "^3.0.0",


### PR DESCRIPTION
Create typings for meow. These depends on minimist, therefore add
minimist typings to package dependencies.