### PR TITLE
Rewrite flags input

### DIFF
--- a/fixture.js
+++ b/fixture.js
@@ -7,14 +7,11 @@ const cli = meow({
 	help: `
 		Usage
 		  foo <input>
-	`
-}, {
-	alias: {
-		u: 'unicorn'
-	},
-	default: {
-		meow: 'dog',
-		camelCaseOption: 'foo'
+	`,
+	flags: {
+		unicorn: {alias: 'u'},
+		meow: {default: 'dog'},
+		camelCaseOption: {default: 'foo'}
 	}
 });
 

--- a/index.js
+++ b/index.js
@@ -14,13 +14,12 @@ const normalizePackageData = require('normalize-package-data');
 delete require.cache[__filename];
 const parentDir = path.dirname(module.parent.filename);
 
-module.exports = opts => {
+module.exports = (helpMessage, opts) => {
 	loudRejection();
 
-	if (Array.isArray(opts) || typeof opts === 'string') {
-		opts = {
-			help: opts
-		};
+	if (typeof helpMessage === 'object' && !Array.isArray(helpMessage)) {
+		opts = helpMessage;
+		helpMessage = '';
 	}
 
 	opts = Object.assign({
@@ -29,17 +28,18 @@ module.exports = opts => {
 			normalize: false
 		}).pkg,
 		argv: process.argv.slice(2),
-		inferType: false
+		inferType: false,
+		input: 'string',
+		help: helpMessage
 	}, opts);
 
-	let minimistOpts = decamelizeKeys(opts.flags || {}, '-', {exclude: ['stopEarly', '--']});
-	minimistOpts = Object.assign({arguments: opts.input || 'string'}, minimistOpts);
+	let minimistOpts = Object.assign({
+		arguments: opts.input
+	}, opts.flags);
 
-	const hasArguments = minimistOpts._ || minimistOpts.arguments;
+	minimistOpts = decamelizeKeys(minimistOpts, '-', {exclude: ['stopEarly', '--']});
 
-	if (opts.inferType && !hasArguments) {
-		minimistOpts.arguments = 'string';
-	} else if (opts.inferType && hasArguments) {
+	if (opts.inferType) {
 		delete minimistOpts.arguments;
 	}
 

--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ module.exports = opts => {
 	}, opts);
 
 	let minimistOpts = decamelizeKeys(opts.flags || {}, '-', {exclude: ['stopEarly', '--']});
-	minimistOpts = Object.assign({arguments: 'string'}, minimistOpts);
+	minimistOpts = Object.assign({arguments: opts.input || 'string'}, minimistOpts);
 
 	const hasArguments = minimistOpts._ || minimistOpts.arguments;
 

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "decamelize-keys": "^1.0.0",
     "loud-rejection": "^1.0.0",
     "minimist": "^1.1.3",
+    "minimist-options": "^3.0.1",
     "normalize-package-data": "^2.3.4",
     "read-pkg-up": "^2.0.0",
     "redent": "^2.0.0",

--- a/readme.md
+++ b/readme.md
@@ -45,8 +45,11 @@ const cli = meow(`
 	  $ foo unicorns --rainbow
 	  🌈 unicorns 🌈
 `, {
-	alias: {
-		r: 'rainbow'
+	flags: {
+		rainbow: {
+			type: 'boolean',
+			alias: 'r'
+		}
 	}
 });
 /*
@@ -133,15 +136,6 @@ Default: `false`
 Infer the argument type.
 
 By default, the argument `5` in `$ foo 5` becomes a string. Enabling this would infer it as a number.
-
-#### minimistOptions
-
-Type: `Object`<br>
-Default: `{}`
-
-Minimist [options](https://github.com/substack/minimist#var-argv--parseargsargs-opts).
-
-Keys passed to the minimist `default` option are [decamelized](https://github.com/sindresorhus/decamelize), so you can for example pass in `fooBar: 'baz'` and have it be the default for the `--foo-bar` flag.
 
 
 ## Promises

--- a/test.js
+++ b/test.js
@@ -10,11 +10,12 @@ test('return object', t => {
 		help: `
 			Usage
 			  foo <input>
-		`
-	}, {
-		alias: {u: 'unicorn'},
-		default: {meow: 'dog'},
-		'--': true
+		`,
+		flags: {
+			unicorn: {alias: 'u'},
+			meow: {default: 'dog'},
+			'--': true
+		}
 	});
 
 	t.is(cli.input[0], 'foo');
@@ -72,17 +73,22 @@ test('single character flag casing should be preserved', t => {
 
 test('type inference', t => {
 	t.is(m({argv: ['5']}).input[0], '5');
-	t.is(m({argv: ['5']}, {string: ['_']}).input[0], '5');
+	t.is(m({argv: ['5']}, {arguments: 'string'}).input[0], '5');
 	t.is(m({
 		argv: ['5'],
 		inferType: true
 	}).input[0], 5);
 	t.is(m({
 		argv: ['5'],
-		inferType: true
-	}, {string: ['foo']}).input[0], 5);
+		inferType: true,
+		flags: {foo: 'string'}
+	}).input[0], 5);
 	t.is(m({
 		argv: ['5'],
-		inferType: true
-	}, {string: ['_', 'foo']}).input[0], 5);
+		inferType: true,
+		flags: {
+			foo: 'string',
+			arguments: 'string'
+		}
+	}).input[0], 5);
 });

--- a/test.js
+++ b/test.js
@@ -96,8 +96,8 @@ test('type inference', t => {
 	}).input[0], 5);
 });
 
-test('alias', t => {
-	t.deepEqual(m({
+test('accept help and options', t => {
+	t.deepEqual(m('help', {
 		argv: ['-f'],
 		flags: {
 			foo: {

--- a/test.js
+++ b/test.js
@@ -95,3 +95,18 @@ test('type inference', t => {
 		input: 'number'
 	}).input[0], 5);
 });
+
+test('alias', t => {
+	t.deepEqual(m({
+		argv: ['-f'],
+		flags: {
+			foo: {
+				type: 'boolean',
+				alias: 'f'
+			}
+		}
+	}).flags, {
+		foo: true,
+		f: true
+	});
+});

--- a/test.js
+++ b/test.js
@@ -73,7 +73,7 @@ test('single character flag casing should be preserved', t => {
 
 test('type inference', t => {
 	t.is(m({argv: ['5']}).input[0], '5');
-	t.is(m({argv: ['5']}, {arguments: 'string'}).input[0], '5');
+	t.is(m({argv: ['5']}, {input: 'string'}).input[0], '5');
 	t.is(m({
 		argv: ['5'],
 		inferType: true
@@ -87,8 +87,11 @@ test('type inference', t => {
 		argv: ['5'],
 		inferType: true,
 		flags: {
-			foo: 'string',
-			arguments: 'string'
+			foo: 'string'
 		}
+	}).input[0], 5);
+	t.is(m({
+		argv: ['5'],
+		input: 'number'
 	}).input[0], 5);
 });


### PR DESCRIPTION
Uses [minimist-options](https://github.com/vadimdemedes/minimist-options) to define minimist options for flags more comfortably.

Before:

```js
const cli = meow({
	description: 'Custom description',
}, {
	alias: {
		u: 'unicorn'
	},
	default: {
		meow: 'dog',
		camelCaseOption: 'foo'
	}
});
```

After:

```js
const cli = meow({
	description: 'Custom description',
	flags: {
		unicorn: {alias: 'u'},
		meow: {default: 'dog'},
		camelCaseOption: {default: 'foo'}
	}
});
```

Note to @sindresorhus: removed the docs from readme, because you wanted to bundle args documentation inside.