### PR TITLE
Add `autoVersion` and `autoHelp` options

### DIFF
--- a/fixture.js
+++ b/fixture.js
@@ -7,7 +7,9 @@ const cli = meow({
 	help: `
 		Usage
 		  foo <input>
-	`
+  `,
+  autoVersion: !process.argv.includes('--no-auto-version'),
+  autoHelp: !process.argv.includes('--no-auto-help')
 }, {
 	alias: {
 		u: 'unicorn'

--- a/fixture.js
+++ b/fixture.js
@@ -8,8 +8,8 @@ const cli = meow({
 		Usage
 		  foo <input>
   `,
-  autoVersion: !process.argv.includes('--no-auto-version'),
-  autoHelp: !process.argv.includes('--no-auto-help')
+  autoVersion: process.argv.indexOf('--no-auto-version') === -1,
+  autoHelp: process.argv.indexOf('--no-auto-help') === -1
 }, {
 	alias: {
 		u: 'unicorn'

--- a/fixture.js
+++ b/fixture.js
@@ -8,8 +8,8 @@ const cli = meow({
 		Usage
 		  foo <input>
   `,
-  autoVersion: process.argv.indexOf('--no-auto-version') === -1,
-  autoHelp: process.argv.indexOf('--no-auto-help') === -1,
+	autoVersion: process.argv.indexOf('--no-auto-version') === -1,
+	autoHelp: process.argv.indexOf('--no-auto-help') === -1,
 	flags: {
 		unicorn: {alias: 'u'},
 		meow: {default: 'dog'},

--- a/index.js
+++ b/index.js
@@ -65,12 +65,16 @@ module.exports = (helpMessage, opts) => {
 		process.exit(typeof code === 'number' ? code : 2);
 	};
 
-	if (argv.version && opts.version !== false && opts.autoVersion !== false) {
+	const showVersion = () => {
 		console.log(typeof opts.version === 'string' ? opts.version : pkg.version);
 		process.exit();
+	};
+
+	if (argv.version && opts.autoVersion !== false) {
+		showVersion();
 	}
 
-	if (argv.help && opts.help !== false && opts.autoHelp !== false) {
+	if (argv.help && opts.autoHelp !== false) {
 		showHelp(0);
 	}
 
@@ -84,6 +88,7 @@ module.exports = (helpMessage, opts) => {
 		flags,
 		pkg,
 		help,
-		showHelp
+		showHelp,
+		showVersion
 	};
 };

--- a/index.js
+++ b/index.js
@@ -30,7 +30,9 @@ module.exports = (helpMessage, opts) => {
 		argv: process.argv.slice(2),
 		inferType: false,
 		input: 'string',
-		help: helpMessage
+		help: helpMessage,
+		autoHelp: true,
+		autoVersion: true
 	}, opts);
 
 	let minimistOpts = Object.assign({
@@ -70,11 +72,11 @@ module.exports = (helpMessage, opts) => {
 		process.exit();
 	};
 
-	if (argv.version && opts.autoVersion !== false) {
+	if (argv.version && opts.autoVersion) {
 		showVersion();
 	}
 
-	if (argv.help && opts.autoHelp !== false) {
+	if (argv.help && opts.autoHelp) {
 		showHelp(0);
 	}
 

--- a/index.js
+++ b/index.js
@@ -66,13 +66,13 @@ module.exports = (opts, minimistOpts) => {
 		process.exit(typeof code === 'number' ? code : 2);
 	};
 
-	if (argv.version && opts.version !== false) {
+	if (argv.version && opts.version !== false && opts.autoVersion !== false) {
 		console.log(typeof opts.version === 'string' ? opts.version : pkg.version);
 		// eslint-disable-next-line unicorn/no-process-exit
 		process.exit();
 	}
 
-	if (argv.help && opts.help !== false) {
+	if (argv.help && opts.help !== false && opts.autoHelp !== false) {
 		showHelp(0);
 	}
 

--- a/readme.md
+++ b/readme.md
@@ -127,16 +127,12 @@ The input is reindented and starting/ending newlines are trimmed which means you
 
 The description will be shown above your help text automatically.
 
-Set it to `false` to disable it altogether.
-
 ##### version
 
 Type: `string` `boolean`<br>
 Default: The package.json `"version"` property
 
 Set a custom version output.
-
-Set it to `false` to disable it altogether.
 
 ##### autoHelp
 

--- a/readme.md
+++ b/readme.md
@@ -75,6 +75,7 @@ Returns an `Object` with:
 - `pkg` *(Object)* - The `package.json` object
 - `help` *(string)* - The help text used with `--help`
 - `showHelp([code=2])` *(Function)* - Show the help text and exit with `code`
+- `showVersion()` *(Function)* - Show the version text and exit
 
 #### options
 
@@ -136,6 +137,20 @@ Default: The package.json `"version"` property
 Set a custom version output.
 
 Set it to `false` to disable it altogether.
+
+##### autoHelp
+
+Type: `boolean`<br>
+Default: `true`
+
+Automatically show the help text when the `--help` flag is present. Useful to set this value to `false` when a CLI manages child CLIs with their own help text.
+
+##### autoVersion
+
+Type: `boolean`<br>
+Default: `true`
+
+Automatically show the version text when the `--version` flag is present. Useful to set this value to `false` when a CLI manages child CLIs with their own version text.
 
 ##### pkg
 

--- a/test.js
+++ b/test.js
@@ -39,9 +39,19 @@ test('spawn cli and show version', async t => {
 	t.is(stdout, pkg.version);
 });
 
+test('spawn cli and not show version', async t => {
+	const {stdout} = await execa('./fixture.js', ['--version', '--no-auto-version']);
+	t.is(stdout, 'version\nautoVersion\nmeow\ncamelCaseOption');
+});
+
 test('spawn cli and show help screen', async t => {
 	const {stdout} = await execa('./fixture.js', ['--help']);
-	t.is(stdout, indentString('\nCustom description\n\nUsage\n  foo <input>\n', 2));
+	t.is(stdout, indentString('\nCustom description\n\nUsage\n  foo <input>\n\n', 2));
+});
+
+test('spawn cli and not show help screen', async t => {
+	const {stdout} = await execa('./fixture.js', ['--help', '--no-auto-help']);
+	t.is(stdout, 'help\nautoHelp\nmeow\ncamelCaseOption');
 });
 
 test('spawn cli and test input', async t => {


### PR DESCRIPTION
Fixes #62 

Adds `autoVersion` and `autoHelp` options. If either is set to false, meow won't handle printing on `--version` and `--help`. This would allow for explicit handling of showing either, possibly in a subcommand context.

**Note**: I had to add an extra `\n` to the `spawn cli and show help screen` test to pass. Not sure if this due to my shell?