### PR TITLE
Add a new option 'psTitle'

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,8 @@ module.exports = (helpMessage, opts) => {
 		argv: process.argv.slice(2),
 		inferType: false,
 		input: 'string',
-		help: helpMessage
+		help: helpMessage,
+		psTitle: true
 	}, opts);
 
 	let minimistOpts = Object.assign({
@@ -51,7 +52,15 @@ module.exports = (helpMessage, opts) => {
 
 	normalizePackageData(pkg);
 
-	process.title = pkg.bin ? Object.keys(pkg.bin)[0] : pkg.name;
+	let processTitle = opts.psTitle;
+
+	if (processTitle) {
+		if (processTitle === true) {
+			processTitle = pkg.bin ? Object.keys(pkg.bin)[0] : pkg.name;
+		}
+
+		process.title = processTitle;
+	}
 
 	let description = opts.description;
 	if (!description && description !== false) {

--- a/test.js
+++ b/test.js
@@ -55,6 +55,23 @@ test('spawn cli and test input flag', async t => {
 	t.is(stdout, 'bar');
 });
 
+test.serial('psTitle as a process.title should work', t => {
+	m({
+		psTitle: false
+	});
+	t.not(process.title, 'meow', 'if psTitle option value evaluate \'false\', it will prevents process.title replaces.');
+
+	m({
+		psTitle: true
+	});
+	t.is(process.title, 'meow', 'Default');
+
+	m({
+		psTitle: 'myApp'
+	});
+	t.is(process.title, 'myApp', 'Custom process.title');
+});
+
 // TODO: This fails in Node.js 7.10.0, but not 6 or 4
 test.serial.skip('pkg.bin as a string should work', t => { // eslint-disable-line ava/no-skip-test
 	m({

--- a/test.js
+++ b/test.js
@@ -59,12 +59,12 @@ test.serial('psTitle as a process.title should work', t => {
 	m({
 		psTitle: false
 	});
-	t.not(process.title, 'meow', 'if psTitle option value evaluate \'false\', it will prevents process.title replaces.');
+	t.not(process.title, pkg.name, 'if psTitle option value evaluate \'false\', it will prevents process.title replaces.');
 
 	m({
 		psTitle: true
 	});
-	t.is(process.title, 'meow', 'Default');
+	t.is(process.title, pkg.name, 'Default');
 
 	m({
 		psTitle: 'myApp'

--- a/test.js
+++ b/test.js
@@ -57,16 +57,25 @@ test('spawn cli and test input flag', async t => {
 
 test.serial('psTitle as a process.title should work', t => {
 	m({
+		pkg: {
+			name: 'meow'
+		},
 		psTitle: false
 	});
-	t.not(process.title, pkg.name, 'if psTitle option value evaluate \'false\', it will prevents process.title replaces.');
+	t.not(process.title, 'meow', 'if psTitle option value evaluate \'false\', it will prevents process.title replaces.');
 
 	m({
+		pkg: {
+			name: 'meow'
+		},
 		psTitle: true
 	});
-	t.is(process.title, pkg.name, 'Default');
+	t.is(process.title, 'meow', 'Default');
 
 	m({
+		pkg: {
+			name: 'meow'
+		},
 		psTitle: 'myApp'
 	});
 	t.is(process.title, 'myApp', 'Custom process.title');


### PR DESCRIPTION
Add a new option called 'psTitle', which is involved in the process.title change.

- psTitle : true `default`
  - `process.title` is pkg.name or pkg.bin
- psTitle : false
  - `process.title` will be natural.
- psTitle : 'myApp' (custom string)
  - `process.title` is custom title from you assigned.

