### PR TITLE
Add test to check boolean flag type enforcement

### DIFF
--- a/test.js
+++ b/test.js
@@ -106,6 +106,16 @@ test('type inference', t => {
 	}).input[0], 5);
 });
 
+test('enforces boolean flag type', t => {
+	const cli = m(``, {
+		argv: ['--cursor=false'],
+		flags: {
+			cursor: {type: 'boolean'}
+		}
+	});
+	t.deepEqual(cli.flags, {cursor: false});
+});
+
 test('accept help and options', t => {
 	t.deepEqual(m('help', {
 		argv: ['-f'],


### PR DESCRIPTION
Resolves #74

I was unable to reproduce #74 with meow v4.0.0 - both the example in the issue and through this unit test - and thought submitting a PR with the test could be helpful. Let me know if there's a better place for this test in the codebase or if there's anything I can do here to help with #74. Thanks. 🙂