### PR TITLE
Do not define unset boolean args

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,13 +32,14 @@ module.exports = (helpMessage, opts) => {
 		input: 'string',
 		help: helpMessage,
 		autoHelp: true,
-		autoVersion: true
+		autoVersion: true,
+		booleanDefault: false
 	}, opts);
 
 	const minimistFlags = opts.flags ? Object.keys(opts.flags).reduce(
 		(flags, flag) => {
-			if (flags[flag].type === 'boolean' && typeof flags[flag].default === 'undefined') {
-				flags[flag].default = undefined;
+			if (flags[flag].type === 'boolean' && !Object.prototype.hasOwnProperty.call(flags[flag], 'default')) {
+				flags[flag].default = opts.booleanDefault;
 			}
 
 			return flags;

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ module.exports = (helpMessage, opts) => {
 		booleanDefault: false
 	}, opts);
 
-	const minimistFlags = opts.flags ? Object.keys(opts.flags).reduce(
+	const minimistFlags = opts.flags && typeof opts.booleanDefault !== 'undefined' ? Object.keys(opts.flags).reduce(
 		(flags, flag) => {
 			if (flags[flag].type === 'boolean' && !Object.prototype.hasOwnProperty.call(flags[flag], 'default')) {
 				flags[flag].default = opts.booleanDefault;
@@ -99,15 +99,7 @@ module.exports = (helpMessage, opts) => {
 	const input = argv._;
 	delete argv._;
 
-	let flags = camelcaseKeys(argv, {exclude: ['--', /^\w$/]});
-
-	flags = Object.keys(flags).reduce((result, flag) => {
-		if (flags[flag] !== undefined) {
-			result[flag] = flags[flag];
-		}
-
-		return result;
-	}, {});
+	const flags = camelcaseKeys(argv, {exclude: ['--', /^\w$/]});
 
 	return {
 		input,

--- a/package.json
+++ b/package.json
@@ -41,12 +41,12 @@
 		"camelcase-keys": "^4.0.0",
 		"decamelize-keys": "^1.0.0",
 		"loud-rejection": "^1.0.0",
-		"minimist": "^1.1.3",
 		"minimist-options": "^3.0.1",
 		"normalize-package-data": "^2.3.4",
 		"read-pkg-up": "^3.0.0",
 		"redent": "^2.0.0",
-		"trim-newlines": "^2.0.0"
+		"trim-newlines": "^2.0.0",
+		"yargs-parser": "^9.0.2"
 	},
 	"devDependencies": {
 		"ava": "*",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
 		"read-pkg-up": "^3.0.0",
 		"redent": "^2.0.0",
 		"trim-newlines": "^2.0.0",
-		"yargs-parser": "^9.0.2"
+		"yargs-parser": "^10.0.0"
 	},
 	"devDependencies": {
 		"ava": "*",

--- a/readme.md
+++ b/readme.md
@@ -173,6 +173,55 @@ Infer the argument type.
 
 By default, the argument `5` in `$ foo 5` becomes a string. Enabling this would infer it as a number.
 
+##### booleanDefault
+
+Type: `boolean` `null` `undefined`<br>
+Default: `false`
+
+Value of `boolean` flags not defined in `argv`.
+If set to `undefined` the flags not defined in `argv` will be excluded from the result.
+The `default` value set in `boolean` flags take precedence over `booleanDefault`.
+
+Example:
+
+```js
+const cli = meow(`
+	Usage
+	  $ foo
+
+	Options
+	  --rainbow, -r  Include a rainbow
+		--unicorn, -r  Include a unicorn
+
+	Examples
+	  $ foo
+	  🌈 unicorns 🌈
+`, {
+	booleanDefault: undefined,
+	flags: {
+		rainbow: {
+			type: 'boolean',
+			default: true
+			alias: 'r'
+		},
+		unicorn: {
+			type: 'boolean',
+			default: false
+			alias: 'u'
+		},
+		cake: {
+			type: 'boolean',
+			alias: 'c'
+		}
+	}
+});
+/*
+{
+	flags: {rainbow: true, unicorn: false},
+	...
+}
+*/
+```
 
 ## Promises
 

--- a/readme.md
+++ b/readme.md
@@ -191,7 +191,7 @@ const cli = meow(`
 
 	Options
 	  --rainbow, -r  Include a rainbow
-		--unicorn, -r  Include a unicorn
+	  --unicorn, -r  Include a unicorn
 
 	Examples
 	  $ foo
@@ -218,7 +218,7 @@ const cli = meow(`
 /*
 {
 	flags: {rainbow: true, unicorn: false},
-	...
+	…
 }
 */
 ```

--- a/test.js
+++ b/test.js
@@ -106,6 +106,27 @@ test('type inference', t => {
 	}).input[0], 5);
 });
 
+test('filter out unset boolean args', t => {
+	t.deepEqual(m('help', {
+		argv: ['--foo'],
+		flags: {
+			foo: {
+				type: 'boolean'
+			},
+			bar: {
+				type: 'boolean'
+			},
+			baz: {
+				type: 'boolean',
+				default: false
+			}
+		}
+	}).flags, {
+		foo: true,
+		baz: false
+	});
+});
+
 test('accept help and options', t => {
 	t.deepEqual(m('help', {
 		argv: ['-f'],

--- a/test.js
+++ b/test.js
@@ -106,9 +106,10 @@ test('type inference', t => {
 	}).input[0], 5);
 });
 
-test('filter out unset boolean args', t => {
+test('booleanDefault: undefined, filter out unset boolean args', t => {
 	t.deepEqual(m('help', {
 		argv: ['--foo'],
+		booleanDefault: undefined,
 		flags: {
 			foo: {
 				type: 'boolean'
@@ -123,6 +124,28 @@ test('filter out unset boolean args', t => {
 		}
 	}).flags, {
 		foo: true,
+		baz: false
+	});
+});
+
+test('boolean args are false by default', t => {
+	t.deepEqual(m('help', {
+		argv: ['--foo'],
+		flags: {
+			foo: {
+				type: 'boolean'
+			},
+			bar: {
+				type: 'boolean',
+				default: true
+			},
+			baz: {
+				type: 'boolean'
+			}
+		}
+	}).flags, {
+		foo: true,
+		bar: true,
 		baz: false
 	});
 });


### PR DESCRIPTION
Proposal to solve xojs/xo#299.

For each boolean arg that doesn't define a `default`, set it to `undefined`. After parsing remove the options with a value of `undefined`.

Unfortunately this doesn't work with `minimist` due to an unrelated bug when using both `default` and `alias`:
```js
minimist(['-f'], {boolean: ['foo'], alias: {f: 'foo'}, default: {foo: null}});
// => {_: [], foo: true, f: [null, true]}
// Should be {_: [], foo: true, f:  true}

minimist(['--foo'], {boolean: ['foo'], alias: {f: 'foo'}, default: {foo: null}});
// => {_: [], foo: true, f: [null, true]}
// Should be {_: [], foo: true, f:  true}
```

I replaced `minimist` with [yargs-parser](https://github.com/yargs/yargs-parser) to solve this issue.

`meow` relies on [minimist-options](https://github.com/vadimdemedes/minimist-options) to transform the options format. It still works with `yargs-parser` as the format is the same.

This PR works as a fix for xojs/xo#299 but it might be a desireable to support the [other yargs-parser options](https://github.com/yargs/yargs-parser#requireyargs-parserargs-opts). That would require to support those option in `minimist-options` or to replace it.

Not sure if it worth the effort though, as [yargs](https://github.com/yargs/yargs) already allow all those options and support the same convenient format as `meow` via the [options function](http://yargs.js.org/docs/#api-optionskey-opt):
```js
const argv = require('yargs')
    .options({
      rainbow: {
	type: 'boolean',
	alias: 'r'
     }
   }).argv;
```



