### PR TITLE
Make loudRejection optional

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,8 +15,6 @@ delete require.cache[__filename];
 const parentDir = path.dirname(module.parent.filename);
 
 module.exports = (helpMessage, options) => {
-	loudRejection();
-
 	if (typeof helpMessage === 'object' && !Array.isArray(helpMessage)) {
 		options = helpMessage;
 		helpMessage = '';
@@ -33,9 +31,12 @@ module.exports = (helpMessage, options) => {
 		help: helpMessage,
 		autoHelp: true,
 		autoVersion: true,
+		loudRejection: true,
 		booleanDefault: false
 	}, options);
 
+	if (options.loudRejection) loudRejection();
+	
 	const minimistFlags = options.flags && typeof options.booleanDefault !== 'undefined' ? Object.keys(options.flags).reduce(
 		(flags, flag) => {
 			if (flags[flag].type === 'boolean' && !Object.prototype.hasOwnProperty.call(flags[flag], 'default')) {


### PR DESCRIPTION
As a followup for #93, this is a simpler change that makes `loudRejection` optional to allow users to define their own handling for uncaught rejections.

Without this, adding a user-defined handler that throws the exception in order to crash the process (i.e. `process.on('unhandledRejection', err => { throw err })`) could result in the log message appearing twice, depending on which handler gets registered first.

This is also the case with `hard-rejection`: enabling it after calling `meow()` results in two error messages, enabling it before `meow()` works as expected, which is somewhat of a confusing behavior.