### PR TITLE
Remove flags aliases from flags output

### DIFF
--- a/index.js
+++ b/index.js
@@ -109,6 +109,12 @@ module.exports = (helpText, options) => {
 
 	const flags = camelcaseKeys(argv, {exclude: ['--', /^\w$/]});
 
+	Object.keys(options.flags).forEach(function(flag){
+		if(options.flags[flag].alias != undefined){
+			delete flags[options.flags[flag].alias];
+		}
+	});
+
 	return {
 		input,
 		flags,


### PR DESCRIPTION
As said in this issue #102, short-flags in the `cli.flags` are a bit messy