### PR TITLE
Feat/add required flags

### DIFF
--- a/fixture.js
+++ b/fixture.js
@@ -11,21 +11,24 @@ const cli = meow({
 	autoVersion: process.argv.indexOf('--no-auto-version') === -1,
 	autoHelp: process.argv.indexOf('--no-auto-help') === -1,
 	flags: {
-		unicorn: {
-			alias: 'u',
-			required: (args) => {
-				if (args.meow) return true;
-				return false;
-			},
+		unicorn: {alias: 'u'},
+		meow: {default: 'dog'},
+		camelCaseOption: {default: 'foo'},
+		fence: {
+			alias: 'f',
+			required(args) {
+				return args.unicorn;
+			}
 		},
-		meow: { required: true },
-		camelCaseOption: { default: 'foo' },
-		fire: { alias: 'f', default: 'fire' },
-	},
+		foo: {
+			alias: 'o',
+			required: true
+		}
+	}
 });
 
 if (cli.flags.camelCaseOption === 'foo') {
-	Object.keys(cli.flags).forEach((x) => {
+	Object.keys(cli.flags).forEach(x => {
 		console.log(x);
 	});
 } else {

--- a/fixture.js
+++ b/fixture.js
@@ -11,14 +11,21 @@ const cli = meow({
 	autoVersion: process.argv.indexOf('--no-auto-version') === -1,
 	autoHelp: process.argv.indexOf('--no-auto-help') === -1,
 	flags: {
-		unicorn: {alias: 'u'},
-		meow: {default: 'dog'},
-		camelCaseOption: {default: 'foo'}
-	}
+		unicorn: {
+			alias: 'u',
+			required: (args) => {
+				if (args.meow) return true;
+				return false;
+			},
+		},
+		meow: { required: true },
+		camelCaseOption: { default: 'foo' },
+		fire: { alias: 'f', default: 'fire' },
+	},
 });
 
 if (cli.flags.camelCaseOption === 'foo') {
-	Object.keys(cli.flags).forEach(x => {
+	Object.keys(cli.flags).forEach((x) => {
 		console.log(x);
 	});
 } else {

--- a/index.js
+++ b/index.js
@@ -113,7 +113,7 @@ module.exports = (helpText, options) => {
 	const input = argv._;
 	delete argv._;
 
-	const flags = camelcaseKeys(argv, {exclude: ['--', /^\w$/]});
+	const flags = camelcaseKeys(argv, { exclude: ['--', /^\w$/] });
 
 	return {
 		input,
@@ -121,6 +121,6 @@ module.exports = (helpText, options) => {
 		pkg,
 		help,
 		showHelp,
-		showVersion
+		showVersion,
 	};
 };

--- a/index.js
+++ b/index.js
@@ -21,10 +21,11 @@ module.exports = (helpText, options) => {
 	}
 
 	options = {
-		pkg: readPkgUp.sync({
-			cwd: parentDir,
-			normalize: false
-		}).pkg || {},
+		pkg:
+			readPkgUp.sync({
+				cwd: parentDir,
+				normalize: false,
+			}).pkg || {},
 		argv: process.argv.slice(2),
 		inferType: false,
 		input: 'string',
@@ -33,30 +34,35 @@ module.exports = (helpText, options) => {
 		autoVersion: true,
 		booleanDefault: false,
 		hardRejection: true,
-		...options
+		...options,
 	};
 
 	if (options.hardRejection) {
 		hardRejection();
 	}
 
-	const minimistFlags = options.flags && typeof options.booleanDefault !== 'undefined' ? Object.keys(options.flags).reduce(
-		(flags, flag) => {
-			if (flags[flag].type === 'boolean' && !Object.prototype.hasOwnProperty.call(flags[flag], 'default')) {
-				flags[flag].default = options.booleanDefault;
-			}
+	const minimistFlags =
+		options.flags && typeof options.booleanDefault !== 'undefined'
+			? Object.keys(options.flags).reduce((flags, flag) => {
+					if (
+						flags[flag].type === 'boolean' &&
+						!Object.prototype.hasOwnProperty.call(flags[flag], 'default')
+					) {
+						flags[flag].default = options.booleanDefault;
+					}
 
-			return flags;
-		},
-		options.flags
-	) : options.flags;
+					return flags;
+			  }, options.flags)
+			: options.flags;
 
 	let minimistoptions = {
 		arguments: options.input,
-		...minimistFlags
+		...minimistFlags,
 	};
 
-	minimistoptions = decamelizeKeys(minimistoptions, '-', {exclude: ['stopEarly', '--']});
+	minimistoptions = decamelizeKeys(minimistoptions, '-', {
+		exclude: ['stopEarly', '--'],
+	});
 
 	if (options.inferType) {
 		delete minimistoptions.arguments;

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ module.exports = (helpText, options) => {
 		pkg:
 			readPkgUp.sync({
 				cwd: parentDir,
-				normalize: false,
+				normalize: false
 			}).pkg || {},
 		argv: process.argv.slice(2),
 		inferType: false,

--- a/test.js
+++ b/test.js
@@ -77,7 +77,7 @@ test('spawn cli and test input flag', async t => {
 });
 
 // TODO: This fails in Node.js 7.10.0, but not 6 or 4
-test.serial('pkg.bin as a string should work', t => {
+test.serial.skip('pkg.bin as a string should work', t => { // eslint-disable-line ava/no-skip-test
 	// eslint-disable-line ava/no-skip-test
 	meow({
 		pkg: {

--- a/test.js
+++ b/test.js
@@ -41,13 +41,19 @@ test('spawn cli and show version', async t => {
 });
 
 test('spawn cli and not show version', async t => {
-	const {stdout} = await execa('./fixture.js', ['--version', '--no-auto-version']);
+	const {stdout} = await execa('./fixture.js', [
+		'--version',
+		'--no-auto-version'
+	]);
 	t.is(stdout, 'version\nautoVersion\nmeow\ncamelCaseOption');
 });
 
 test('spawn cli and show help screen', async t => {
 	const {stdout} = await execa('./fixture.js', ['--help']);
-	t.is(stdout, indentString('\nCustom description\n\nUsage\n  foo <input>\n\n', 2));
+	t.is(
+		stdout,
+		indentString('\nCustom description\n\nUsage\n  foo <input>\n\n', 2)
+	);
 });
 
 test('spawn cli and not show help screen', async t => {
@@ -61,12 +67,18 @@ test('spawn cli and test input', async t => {
 });
 
 test('spawn cli and test input flag', async t => {
-	const {stdout} = await execa('./fixture.js', ['--camel-case-option', 'bar']);
+	const {stdout} = await execa('./fixture.js', [
+		'--camel-case-option',
+		'bar',
+		'--foo',
+		'can'
+	]);
 	t.is(stdout, 'bar');
 });
 
 // TODO: This fails in Node.js 7.10.0, but not 6 or 4
-test.serial.skip('pkg.bin as a string should work', t => { // eslint-disable-line ava/no-skip-test
+test.serial('pkg.bin as a string should work', t => {
+	// eslint-disable-line ava/no-skip-test
 	meow({
 		pkg: {
 			name: 'browser-sync',
@@ -84,70 +96,88 @@ test('single character flag casing should be preserved', t => {
 test('type inference', t => {
 	t.is(meow({argv: ['5']}).input[0], '5');
 	t.is(meow({argv: ['5']}, {input: 'string'}).input[0], '5');
-	t.is(meow({
-		argv: ['5'],
-		inferType: true
-	}).input[0], 5);
-	t.is(meow({
-		argv: ['5'],
-		inferType: true,
-		flags: {foo: 'string'}
-	}).input[0], 5);
-	t.is(meow({
-		argv: ['5'],
-		inferType: true,
-		flags: {
-			foo: 'string'
-		}
-	}).input[0], 5);
-	t.is(meow({
-		argv: ['5'],
-		input: 'number'
-	}).input[0], 5);
+	t.is(
+		meow({
+			argv: ['5'],
+			inferType: true
+		}).input[0],
+		5
+	);
+	t.is(
+		meow({
+			argv: ['5'],
+			inferType: true,
+			flags: {foo: 'string'}
+		}).input[0],
+		5
+	);
+	t.is(
+		meow({
+			argv: ['5'],
+			inferType: true,
+			flags: {
+				foo: 'string'
+			}
+		}).input[0],
+		5
+	);
+	t.is(
+		meow({
+			argv: ['5'],
+			input: 'number'
+		}).input[0],
+		5
+	);
 });
 
 test('booleanDefault: undefined, filter out unset boolean args', t => {
-	t.deepEqual(meow({
-		argv: ['--foo'],
-		booleanDefault: undefined,
-		flags: {
-			foo: {
-				type: 'boolean'
-			},
-			bar: {
-				type: 'boolean'
-			},
-			baz: {
-				type: 'boolean',
-				default: false
+	t.deepEqual(
+		meow({
+			argv: ['--foo'],
+			booleanDefault: undefined,
+			flags: {
+				foo: {
+					type: 'boolean'
+				},
+				bar: {
+					type: 'boolean'
+				},
+				baz: {
+					type: 'boolean',
+					default: false
+				}
 			}
+		}).flags,
+		{
+			foo: true,
+			baz: false
 		}
-	}).flags, {
-		foo: true,
-		baz: false
-	});
+	);
 });
 
 test('boolean args are false by default', t => {
-	t.deepEqual(meow({
-		argv: ['--foo'],
-		flags: {
-			foo: {
-				type: 'boolean'
-			},
-			bar: {
-				type: 'boolean',
-				default: true
-			},
-			baz: {
-				type: 'boolean'
+	t.deepEqual(
+		meow({
+			argv: ['--foo'],
+			flags: {
+				foo: {
+					type: 'boolean'
+				},
+				bar: {
+					type: 'boolean',
+					default: true
+				},
+				baz: {
+					type: 'boolean'
+				}
 			}
+		}).flags,
+		{
+			foo: true,
+			bar: true,
+			baz: false
 		}
-	}).flags, {
-		foo: true,
-		bar: true,
-		baz: false
-	});
+	);
 });
 
 test('enforces boolean flag type', t => {
@@ -163,18 +193,21 @@ test('enforces boolean flag type', t => {
 });
 
 test('accept help and options', t => {
-	t.deepEqual(meow({
-		argv: ['-f'],
-		flags: {
-			foo: {
-				type: 'boolean',
-				alias: 'f'
+	t.deepEqual(
+		meow({
+			argv: ['-f'],
+			flags: {
+				foo: {
+					type: 'boolean',
+					alias: 'f'
+				}
 			}
+		}).flags,
+		{
+			foo: true,
+			f: true
 		}
-	}).flags, {
-		foo: true,
-		f: true
-	});
+	);
 });
 
 test('grouped short-flags work', t => {
@@ -197,4 +230,42 @@ test('grouped short-flags work', t => {
 	t.true(flags.loco);
 	t.true(flags.c);
 	t.true(flags.l);
+});
+
+test('required flag', async t => {
+	const {stdout} = await execa('./fixture.js', [
+		'--meow',
+		'cat'
+	]);
+	t.is(stdout, 'Missing required option:\n  --foo, -o\n\nRun with --help to view help information.');
+});
+
+test('provisional require', async t => {
+	const {stdout: i} = await execa('./fixture.js', [
+		'--unicorn',
+		'cat',
+		'--foo',
+		'jump'
+	]);
+
+	const {stdout: f} = await execa('./fixture.js', [
+		'--meow',
+		'cat'
+	]);
+
+	t.is(i, 'Missing required option:\n  --fence, -f\n\nRun with --help to view help information.');
+	t.is(f, 'Missing required option:\n  --foo, -o\n\nRun with --help to view help information.');
+});
+
+test('require doesn\'t block help and version requests', async t => {
+	const {stdout: help} = await execa('./fixture.js', [
+		'--help'
+	]);
+	const {stdout: version} = await execa('./fixture.js', [
+		'--version'
+	]);
+	t.is(
+		help,
+		indentString('\nCustom description\n\nUsage\n  foo <input>\n\n', 2));
+	t.is(version, pkg.version);
 });


### PR DESCRIPTION
Fixes #51.

This pull request attempts adding the feature to enable required flags.

Examples:
1. Making a flag required:

```javascript
const cli = meow({
	description: 'Custom description',
	help: `
		Usage
		  foo <input>
  `,
	flags: {
		foo: {
			alias: 'o',
			required: true
		}
	}
});
```
Output without required flag:

```
Missing required option
  --foo, -o

Run with --help to view help information.
```

2. Creating provisional required flags. These flags are only required if another flag is present.

```javascript
const cli = meow({
	description: 'Custom description',
	help: `
		Usage
		  foo <input>
  `,
	flags: {
		unicorn: {alias: 'u'},
		fence: {
			alias: 'f',
			required(args) {
				return args.unicorn;
			}
		},
	}
});
```
`fixture --unicorn="horns"`

The command above would make `fence` a required flag. Meaning `fence` is only required if `unicorn` is present.
