### PR TITLE
Added support for multiple option

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,6 +58,12 @@ module.exports = (helpText, options) => {
 
 	minimistoptions = decamelizeKeys(minimistoptions, '-', {exclude: ['stopEarly', '--']});
 
+	Object.keys(minimistoptions).forEach(key => {
+		if (minimistoptions[key].multiple) {
+			minimistoptions[key].type = 'array';
+		}
+	});
+
 	if (options.inferType) {
 		delete minimistoptions.arguments;
 	}

--- a/index.js
+++ b/index.js
@@ -69,6 +69,11 @@ module.exports = (helpText, options) => {
 	}
 
 	minimistoptions = buildMinimistOptions(minimistoptions);
+	minimistoptions.configuration = {
+		...(minimistoptions.configuration || {}),
+		// @see: https://github.com/sindresorhus/meow/issues/111
+		'duplicate-arguments-array': false
+	};
 
 	if (minimistoptions['--']) {
 		minimistoptions.configuration = {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
 		"camelcase-keys": "^5.0.0",
 		"decamelize-keys": "^1.0.0",
 		"hard-rejection": "^1.0.0",
-		"minimist-options": "^3.0.1",
+		"minimist-options": "^4.0.0",
 		"normalize-package-data": "^2.3.4",
 		"read-pkg-up": "^4.0.0",
 		"redent": "^2.0.0",

--- a/readme.md
+++ b/readme.md
@@ -101,6 +101,7 @@ The key is the flag name and the value is an object with any of:
 - `type`: Type of value. (Possible values: `string` `boolean`)
 - `alias`: Usually used to define a short flag alias.
 - `default`: Default value when the flag is not specified.
+- `multiple`: If `true` parse the flag as an array (Only available on strings)
 
 Example:
 
@@ -109,7 +110,8 @@ flags: {
 	unicorn: {
 		type: 'string',
 		alias: 'u',
-		default: 'rainbow'
+		default: 'rainbow',
+		multiple: false
 	}
 }
 ```

--- a/test.js
+++ b/test.js
@@ -81,6 +81,28 @@ test('single character flag casing should be preserved', t => {
 	t.deepEqual(meow({argv: ['-F']}).flags, {F: true});
 });
 
+test('string flags with multiple options are always arrays', t => {
+	const flags = {
+		foo: {
+			type: 'string',
+			multiple: true
+		}
+	};
+
+	t.deepEqual(meow({
+		flags,
+		argv: ['--foo=a']
+	}).flags, {foo: ['a']});
+
+	t.deepEqual(meow({
+		flags,
+		argv: [
+			'--foo=a',
+			'--foo=b'
+		]
+	}).flags, {foo: ['a', 'b']});
+});
+
 test('type inference', t => {
 	t.is(meow({argv: ['5']}).input[0], '5');
 	t.is(meow({argv: ['5']}, {input: 'string'}).input[0], '5');

--- a/test.js
+++ b/test.js
@@ -107,6 +107,11 @@ test('string flags with multiple options are always arrays', t => {
 
 	t.deepEqual(meow({
 		flags,
+		argv: ['--foo', 'a', 'b']
+	}).flags, {foo: ['a', 'b']});
+
+	t.deepEqual(meow({
+		flags,
 		argv: [
 			'--foo=a',
 			'--foo=b'

--- a/test.js
+++ b/test.js
@@ -81,6 +81,17 @@ test('single character flag casing should be preserved', t => {
 	t.deepEqual(meow({argv: ['-F']}).flags, {F: true});
 });
 
+test('string flag return one result when not multiple', t => {
+	t.deepEqual(meow({
+		flags: {
+			foo: {
+				type: 'string'
+			}
+		},
+		argv: ['--foo=a', '--foo=b']
+	}).flags, {foo: 'b'});
+});
+
 test('string flags with multiple options are always arrays', t => {
 	const flags = {
 		foo: {


### PR DESCRIPTION
When the `multiple` option is set **true** on string type flags the parsed value is always an array, closes #111 

#### Observations

I see you are using yargs-parsers but creating the options for it with minimist-options, I see they have pretty much the same config and it's working pretty good but I've noticed this difference while making this PR: 

The [array](https://github.com/vadimdemedes/minimist-options#usage) type of minimist-options turns into: `array: ['arr']` while the array options of yargs-parser is more complex and can take [objects](https://github.com/yargs/yargs-parser#api) for better definition of the expected arguments, so maybe this could lead to having the  `multiple` on boolean flags too.

Do you think is necessary to have minimist-options to parse flags for you or it can be substituted with a custom function that will complain more with yargs-parser style of options?

Sorry for my bad english :(