### PR TITLE
Update dependencies, refactor TypeScript definition to CommonJS compatible export

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,198 +1,238 @@
 import {PackageJson} from 'type-fest';
 import {Options as MinimistOptions} from 'minimist-options';
 
-export interface Options {
-	/**
-	Define argument flags.
+declare namespace meow {
+	interface Options {
+		/**
+		Define argument flags.
 
-	The key is the flag name and the value is an object with any of:
+		The key is the flag name and the value is an object with any of:
 
-	- `type`: Type of value. (Possible values: `string` `boolean`)
-	- `alias`: Usually used to define a short flag alias.
-	- `default`: Default value when the flag is not specified.
+		- `type`: Type of value. (Possible values: `string` `boolean`)
+		- `alias`: Usually used to define a short flag alias.
+		- `default`: Default value when the flag is not specified.
 
-	@example
-	```
-	flags: {
-		unicorn: {
-			type: 'string',
-			alias: 'u',
-			default: 'rainbow'
-		}
-	}
-	```
-	*/
-	readonly flags?: MinimistOptions;
-
-	/**
-	Description to show above the help text. Default: The package.json `"description"` property.
-
-	Set it to `false` to disable it altogether.
-	*/
-	readonly description?: string | false;
-
-	/**
-	The help text you want shown.
-
-	The input is reindented and starting/ending newlines are trimmed which means you can use a [template literal](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/template_strings) without having to care about using the correct amount of indent.
-
-	The description will be shown above your help text automatically.
-
-	Set it to `false` to disable it altogether.
-	*/
-	readonly help?: string | false;
-
-	/**
-	Set a custom version output. Default: The package.json `"version"` property.
-
-	Set it to `false` to disable it altogether.
-	*/
-	readonly version?: string | false;
-
-	/**
-	Automatically show the help text when the `--help` flag is present. Useful to set this value to `false` when a CLI manages child CLIs with their own help text.
-	*/
-	readonly autoHelp?: boolean;
-
-	/**
-	Automatically show the version text when the `--version` flag is present. Useful to set this value to `false` when a CLI manages child CLIs with their own version text.
-	*/
-	readonly autoVersion?: boolean;
-
-	/**
-	package.json as an `Object`. Default: Closest package.json upwards.
-
-	_You most likely don't need this option._
-	*/
-	readonly pkg?: {[key: string]: unknown};
-
-	/**
-	Custom arguments object.
-
-	@default process.argv.slice(2)
-	*/
-	readonly argv?: ReadonlyArray<string>;
-
-	/**
-	Infer the argument type.
-
-	By default, the argument `5` in `$ foo 5` becomes a string. Enabling this would infer it as a number.
-
-	@default false
-	*/
-	readonly inferType?: boolean;
-
-	/**
-	Value of `boolean` flags not defined in `argv`. If set to `undefined` the flags not defined in `argv` will be excluded from the result. The `default` value set in `boolean` flags take precedence over `booleanDefault`.
-
-	__Caution: Explicitly specifying undefined for `booleanDefault` has different meaning from omitting key itself.__
-
-	@example
-	```
-	const cli = meow(`
-		Usage
-			$ foo
-
-		Options
-			--rainbow, -r  Include a rainbow
-			--unicorn, -u  Include a unicorn
-			--no-sparkles  Exclude sparkles
-
-		Examples
-			$ foo
-			🌈 unicorns✨🌈
-	`, {
-		booleanDefault: undefined,
+		@example
+		```
 		flags: {
-			rainbow: {
-				type: 'boolean',
-				default: true,
-				alias: 'r'
-			},
-				unicorn: {
-				type: 'boolean',
-				default: false,
-				alias: 'u'
-			},
-			cake: {
-				type: 'boolean',
-				alias: 'c'
-			},
-			sparkles: {
-				type: 'boolean',
-				default: true
+			unicorn: {
+				type: 'string',
+				alias: 'u',
+				default: 'rainbow'
 			}
 		}
-	});
+		```
+		*/
+		readonly flags?: MinimistOptions;
 
-	//{
-	//	flags: {
-	//		rainbow: true,
-	//		unicorn: false,
-	//		sparkles: true
-	//	},
-	//	unnormalizedFlags: {
-	//		rainbow: true,
-	//		r: true,
-	//		unicorn: false,
-	//		u: false,
-	//		sparkles: true
-	//	},
-	//	…
-	//}
-	```
-	*/
-	readonly booleanDefault?: boolean | null | undefined;
+		/**
+		Description to show above the help text. Default: The package.json `"description"` property.
 
-	/**
-	Whether to use [hard-rejection](https://github.com/sindresorhus/hard-rejection) or not. Disabling this can be useful if you need to handle `process.on('unhandledRejection')` yourself.
+		Set it to `false` to disable it altogether.
+		*/
+		readonly description?: string | false;
 
-	@default true
-	*/
-	readonly hardRejection?: boolean;
+		/**
+		The help text you want shown.
+
+		The input is reindented and starting/ending newlines are trimmed which means you can use a [template literal](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/template_strings) without having to care about using the correct amount of indent.
+
+		The description will be shown above your help text automatically.
+
+		Set it to `false` to disable it altogether.
+		*/
+		readonly help?: string | false;
+
+		/**
+		Set a custom version output. Default: The package.json `"version"` property.
+
+		Set it to `false` to disable it altogether.
+		*/
+		readonly version?: string | false;
+
+		/**
+		Automatically show the help text when the `--help` flag is present. Useful to set this value to `false` when a CLI manages child CLIs with their own help text.
+		*/
+		readonly autoHelp?: boolean;
+
+		/**
+		Automatically show the version text when the `--version` flag is present. Useful to set this value to `false` when a CLI manages child CLIs with their own version text.
+		*/
+		readonly autoVersion?: boolean;
+
+		/**
+		package.json as an `Object`. Default: Closest package.json upwards.
+
+		_You most likely don't need this option._
+		*/
+		readonly pkg?: {[key: string]: unknown};
+
+		/**
+		Custom arguments object.
+
+		@default process.argv.slice(2)
+		*/
+		readonly argv?: ReadonlyArray<string>;
+
+		/**
+		Infer the argument type.
+
+		By default, the argument `5` in `$ foo 5` becomes a string. Enabling this would infer it as a number.
+
+		@default false
+		*/
+		readonly inferType?: boolean;
+
+		/**
+		Value of `boolean` flags not defined in `argv`. If set to `undefined` the flags not defined in `argv` will be excluded from the result. The `default` value set in `boolean` flags take precedence over `booleanDefault`.
+
+		__Caution: Explicitly specifying undefined for `booleanDefault` has different meaning from omitting key itself.__
+
+		@example
+		```
+		import meow = require('meow');
+
+		const cli = meow(`
+			Usage
+				$ foo
+
+			Options
+				--rainbow, -r  Include a rainbow
+				--unicorn, -u  Include a unicorn
+				--no-sparkles  Exclude sparkles
+
+			Examples
+				$ foo
+				🌈 unicorns✨🌈
+		`, {
+			booleanDefault: undefined,
+			flags: {
+				rainbow: {
+					type: 'boolean',
+					default: true,
+					alias: 'r'
+				},
+					unicorn: {
+					type: 'boolean',
+					default: false,
+					alias: 'u'
+				},
+				cake: {
+					type: 'boolean',
+					alias: 'c'
+				},
+				sparkles: {
+					type: 'boolean',
+					default: true
+				}
+			}
+		});
+
+		//{
+		//	flags: {
+		//		rainbow: true,
+		//		unicorn: false,
+		//		sparkles: true
+		//	},
+		//	unnormalizedFlags: {
+		//		rainbow: true,
+		//		r: true,
+		//		unicorn: false,
+		//		u: false,
+		//		sparkles: true
+		//	},
+		//	…
+		//}
+		```
+		*/
+		readonly booleanDefault?: boolean | null | undefined;
+
+		/**
+		Whether to use [hard-rejection](https://github.com/sindresorhus/hard-rejection) or not. Disabling this can be useful if you need to handle `process.on('unhandledRejection')` yourself.
+
+		@default true
+		*/
+		readonly hardRejection?: boolean;
+	}
+
+	interface Result {
+		/**
+		Non-flag arguments.
+		*/
+		input: string[];
+
+		/**
+		Flags converted to camelCase excluding aliases.
+		*/
+		flags: {[name: string]: unknown};
+
+		/**
+		Flags converted camelCase including aliases.
+		*/
+		unnormalizedFlags: {[name: string]: unknown};
+
+		/**
+		The `package.json` object.
+		*/
+		pkg: PackageJson;
+
+		/**
+		The help text used with `--help`.
+		*/
+		help: string;
+
+		/**
+		Show the help text and exit with code.
+
+		@param exitCode - The exit code to use. Default: `2`.
+		*/
+		showHelp(exitCode?: number): void;
+
+		/**
+		Show the version text and exit.
+		*/
+		showVersion(): void;
+	}
 }
-
-export interface Result {
-	/**
-	Non-flag arguments.
-	*/
-	input: string[];
-
-	/**
-	Flags converted to camelCase excluding aliases.
-	*/
-	flags: {[name: string]: unknown};
-
-	/**
-	Flags converted camelCase including aliases.
-	*/
-	unnormalizedFlags: {[name: string]: unknown};
-
-	/**
-	The `package.json` object.
-	*/
-	pkg: PackageJson;
-
-	/**
-	The help text used with `--help`.
-	*/
-	help: string;
-
-	/**
-	Show the help text and exit with code.
-
-	@param exitCode - The exit code to use. Default: `2`.
-	*/
-	showHelp(exitCode?: number): void;
-
-	/**
-	Show the version text and exit.
-	*/
-	showVersion(): void;
-}
-
 /**
 @param helpMessage - Shortcut for the `help` option.
+
+@example
+```
+#!/usr/bin/env node
+'use strict';
+import meow = require('meow');
+import foo = require('.');
+
+const cli = meow(`
+	Usage
+	  $ foo <input>
+
+	Options
+	  --rainbow, -r  Include a rainbow
+
+	Examples
+	  $ foo unicorns --rainbow
+	  🌈 unicorns 🌈
+`, {
+	flags: {
+		rainbow: {
+			type: 'boolean',
+			alias: 'r'
+		}
+	}
+});
+
+//{
+//	input: ['unicorns'],
+//	flags: {rainbow: true},
+//	...
+//}
+
+foo(cli.input[0], cli.flags);
+```
 */
-export default function meow(helpMessage: string, options?: Options): Result;
-export default function meow(options?: Options): Result;
+declare function meow(helpMessage: string, options?: meow.Options): meow.Result;
+declare function meow(options?: meow.Options): meow.Result;
+
+export = meow;

--- a/index.js
+++ b/index.js
@@ -128,4 +128,3 @@ const meow = (helpText, options) => {
 };
 
 module.exports = meow;
-module.exports.default = meow;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,6 +1,7 @@
-import {expectType} from 'tsd-check';
+import {expectType} from 'tsd';
 import {PackageJson} from 'type-fest';
-import meow, {Result} from '.';
+import meow = require('.');
+import {Result} from '.';
 
 expectType<Result>(meow('Help text'));
 expectType<Result>(meow('Help text', {hardRejection: false}));

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 		"node": ">=8"
 	},
 	"scripts": {
-		"test": "xo && ava && tsd-check"
+		"test": "xo && ava && tsd"
 	},
 	"files": [
 		"index.js",
@@ -45,17 +45,17 @@
 		"hard-rejection": "^2.0.0",
 		"minimist-options": "^4.0.1",
 		"normalize-package-data": "^2.5.0",
-		"read-pkg-up": "^4.0.0",
+		"read-pkg-up": "^5.0.0",
 		"redent": "^2.0.0",
 		"trim-newlines": "^2.0.0",
 		"type-fest": "^0.3.0",
 		"yargs-parser": "^13.0.0"
 	},
 	"devDependencies": {
-		"ava": "^1.3.1",
+		"ava": "^1.4.1",
 		"execa": "^1.0.0",
 		"indent-string": "^3.2.0",
-		"tsd-check": "^0.5.0",
+		"tsd": "^0.7.1",
 		"xo": "^0.24.0"
 	},
 	"xo": {

--- a/readme.md
+++ b/readme.md
@@ -192,6 +192,8 @@ The `default` value set in `boolean` flags take precedence over `booleanDefault`
 Example:
 
 ```js
+const meow = require('meow');
+
 const cli = meow(`
 	Usage
 	  $ foo


### PR DESCRIPTION
@sindresorhus This should be part of 6.0.0 milestone.

See [this issue](https://github.com/sindresorhus/mem/issues/31) regarding the definition changes.