### PR TITLE
Add type information for flags

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -160,11 +160,11 @@ declare namespace meow {
 	}
 
 	type TypedFlags<Flags extends MinimistOptions> = {
-		[F in keyof Flags]: Flags[F] extends { type: 'number' }
+		[F in keyof Flags]: Flags[F] extends {type: 'number'}
 			? number
-			: Flags[F] extends { type: 'string' }
+			: Flags[F] extends {type: 'string'}
 				? string
-				: Flags[F] extends { type: 'boolean' }
+				: Flags[F] extends {type: 'boolean'}
 					? boolean
 					: unknown;
 	};

--- a/index.d.ts
+++ b/index.d.ts
@@ -178,12 +178,12 @@ declare namespace meow {
 		/**
 		Flags converted to camelCase excluding aliases.
 		*/
-		flags: TypedFlags<Flags>;
+		flags: TypedFlags<Flags> & {[name: string]: unknown};
 
 		/**
 		Flags converted camelCase including aliases.
 		*/
-		unnormalizedFlags: {[name: string]: unknown};
+		unnormalizedFlags: TypedFlags<Flags> & {[name: string]: unknown};
 
 		/**
 		The `package.json` object.

--- a/index.d.ts
+++ b/index.d.ts
@@ -160,11 +160,11 @@ declare namespace meow {
 	}
 
 	type TypedFlags<Flags extends MinimistOptions> = {
-		[F in keyof Flags]: Flags[F] extends { type: 'number' } | 'number'
+		[F in keyof Flags]: Flags[F] extends { type: 'number' }
 			? number
-			: Flags[F] extends { type: 'string' } | 'string'
+			: Flags[F] extends { type: 'string' }
 				? string
-				: Flags[F] extends { type: 'boolean' } | 'boolean'
+				: Flags[F] extends { type: 'boolean' }
 					? boolean
 					: unknown;
 	};

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,7 @@ import {PackageJson} from 'type-fest';
 import {Options as MinimistOptions} from 'minimist-options';
 
 declare namespace meow {
-	interface Options {
+	interface Options<Flags extends MinimistOptions> {
 		/**
 		Define argument flags.
 
@@ -23,7 +23,7 @@ declare namespace meow {
 		}
 		```
 		*/
-		readonly flags?: MinimistOptions;
+		readonly flags?: Flags;
 
 		/**
 		Description to show above the help text. Default: The package.json `"description"` property.
@@ -159,7 +159,17 @@ declare namespace meow {
 		readonly hardRejection?: boolean;
 	}
 
-	interface Result {
+	type TypedFlags<Flags extends MinimistOptions> = {
+		[F in keyof Flags]: Flags[F] extends { type: 'number' } | 'number'
+			? number
+			: Flags[F] extends { type: 'string' } | 'string'
+				? string
+				: Flags[F] extends { type: 'boolean' } | 'boolean'
+					? boolean
+					: unknown;
+	};
+
+	interface Result<Flags extends MinimistOptions> {
 		/**
 		Non-flag arguments.
 		*/
@@ -168,7 +178,7 @@ declare namespace meow {
 		/**
 		Flags converted to camelCase excluding aliases.
 		*/
-		flags: {[name: string]: unknown};
+		flags: TypedFlags<Flags>;
 
 		/**
 		Flags converted camelCase including aliases.
@@ -236,7 +246,7 @@ const cli = meow(`
 foo(cli.input[0], cli.flags);
 ```
 */
-declare function meow(helpMessage: string, options?: meow.Options): meow.Result;
-declare function meow(options?: meow.Options): meow.Result;
+declare function meow<Flags extends MinimistOptions>(helpMessage: string, options?: meow.Options<Flags>): meow.Result<Flags>;
+declare function meow<Flags extends MinimistOptions>(options?: meow.Options<Flags>): meow.Result<Flags>;
 
 export = meow;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,26 +1,26 @@
-import {expectType} from 'tsd';
+import {expectAssignable, expectType} from 'tsd';
 import {PackageJson} from 'type-fest';
 import meow = require('.');
 import {Result} from '.';
 
 expectType<Result<never>>(meow('Help text'));
 expectType<Result<never>>(meow('Help text', {hardRejection: false}));
-expectType<{flags: {foo: number}}>(
+expectAssignable<{flags: {foo: number}}>(
 	meow({flags: {foo: {type: 'number'}}})
 );
-expectType<{flags: {foo: string}}>(
+expectAssignable<{flags: {foo: string}}>(
 	meow({flags: {foo: {type: 'string'}}})
 );
-expectType<{flags: {foo: boolean}}>(
+expectAssignable<{flags: {foo: boolean}}>(
 	meow({flags: {foo: {type: 'boolean'}}})
 );
-expectType<{flags: {foo: number}}>(
+expectAssignable<{flags: {foo: number}}>(
 	meow({flags: {foo: 'number'}})
 );
-expectType<{flags: {foo: string}}>(
+expectAssignable<{flags: {foo: string}}>(
 	meow({flags: {foo: 'string'}})
 );
-expectType<{flags: {foo: boolean}}>(
+expectAssignable<{flags: {foo: boolean}}>(
 	meow({flags: {foo: 'boolean'}})
 );
 expectType<Result<never>>(meow({description: 'foo'}));

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -3,42 +3,45 @@ import {PackageJson} from 'type-fest';
 import meow = require('.');
 import {Result} from '.';
 
-expectType<Result>(meow('Help text'));
-expectType<Result>(meow('Help text', {hardRejection: false}));
-expectType<Result>(
-	meow({
-		flags: {
-			unicorn: {
-				type: 'boolean',
-				alias: 'u'
-			},
-			fooBar: {
-				type: 'string',
-				default: 'foo'
-			}
-		}
-	})
+expectType<Result<never>>(meow('Help text'));
+expectType<Result<never>>(meow('Help text', {hardRejection: false}));
+expectType<{flags: {foo: number}}>(
+	meow({flags: {foo: {type: 'number'}}})
 );
-expectType<Result>(meow({description: 'foo'}));
-expectType<Result>(meow({description: false}));
-expectType<Result>(meow({help: 'foo'}));
-expectType<Result>(meow({help: false}));
-expectType<Result>(meow({version: 'foo'}));
-expectType<Result>(meow({version: false}));
-expectType<Result>(meow({autoHelp: false}));
-expectType<Result>(meow({autoVersion: false}));
-expectType<Result>(meow({pkg: {foo: 'bar'}}));
-expectType<Result>(meow({argv: ['foo', 'bar']}));
-expectType<Result>(meow({inferType: true}));
-expectType<Result>(meow({booleanDefault: true}));
-expectType<Result>(meow({booleanDefault: null}));
-expectType<Result>(meow({booleanDefault: undefined}));
-expectType<Result>(meow({hardRejection: false}));
+expectType<{flags: {foo: string}}>(
+	meow({flags: {foo: {type: 'string'}}})
+);
+expectType<{flags: {foo: boolean}}>(
+	meow({flags: {foo: {type: 'boolean'}}})
+);
+expectType<{flags: {foo: number}}>(
+	meow({flags: {foo: 'number'}})
+);
+expectType<{flags: {foo: string}}>(
+	meow({flags: {foo: 'string'}})
+);
+expectType<{flags: {foo: boolean}}>(
+	meow({flags: {foo: 'boolean'}})
+);
+expectType<Result<never>>(meow({description: 'foo'}));
+expectType<Result<never>>(meow({description: false}));
+expectType<Result<never>>(meow({help: 'foo'}));
+expectType<Result<never>>(meow({help: false}));
+expectType<Result<never>>(meow({version: 'foo'}));
+expectType<Result<never>>(meow({version: false}));
+expectType<Result<never>>(meow({autoHelp: false}));
+expectType<Result<never>>(meow({autoVersion: false}));
+expectType<Result<never>>(meow({pkg: {foo: 'bar'}}));
+expectType<Result<never>>(meow({argv: ['foo', 'bar']}));
+expectType<Result<never>>(meow({inferType: true}));
+expectType<Result<never>>(meow({booleanDefault: true}));
+expectType<Result<never>>(meow({booleanDefault: null}));
+expectType<Result<never>>(meow({booleanDefault: undefined}));
+expectType<Result<never>>(meow({hardRejection: false}));
 
 const result = meow('Help text');
 
 expectType<string[]>(result.input);
-expectType<{[name: string]: unknown}>(result.flags);
 expectType<{[name: string]: unknown}>(result.unnormalizedFlags);
 expectType<PackageJson>(result.pkg);
 expectType<string>(result.help);

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -39,12 +39,22 @@ expectType<Result<never>>(meow({booleanDefault: null}));
 expectType<Result<never>>(meow({booleanDefault: undefined}));
 expectType<Result<never>>(meow({hardRejection: false}));
 
-const result = meow('Help text');
+const result = meow('Help text', {
+	flags: {
+		foo: {type: 'boolean', alias: 'f'},
+		'foo-bar': 'number'
+	}}
+);
 
 expectType<string[]>(result.input);
-expectType<{[name: string]: unknown}>(result.unnormalizedFlags);
 expectType<PackageJson>(result.pkg);
 expectType<string>(result.help);
+
+expectType<boolean>(result.flags.foo);
+expectType<boolean>(result.unnormalizedFlags.foo);
+expectType<unknown>(result.unnormalizedFlags.f);
+expectType<number>(result.unnormalizedFlags['foo-bar']);
+expectType<unknown>(result.flags.fooBar);
 
 result.showHelp();
 result.showHelp(1);

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -14,15 +14,6 @@ expectAssignable<{flags: {foo: string}}>(
 expectAssignable<{flags: {foo: boolean}}>(
 	meow({flags: {foo: {type: 'boolean'}}})
 );
-expectAssignable<{flags: {foo: number}}>(
-	meow({flags: {foo: 'number'}})
-);
-expectAssignable<{flags: {foo: string}}>(
-	meow({flags: {foo: 'string'}})
-);
-expectAssignable<{flags: {foo: boolean}}>(
-	meow({flags: {foo: 'boolean'}})
-);
 expectType<Result<never>>(meow({description: 'foo'}));
 expectType<Result<never>>(meow({description: false}));
 expectType<Result<never>>(meow({help: 'foo'}));
@@ -42,7 +33,7 @@ expectType<Result<never>>(meow({hardRejection: false}));
 const result = meow('Help text', {
 	flags: {
 		foo: {type: 'boolean', alias: 'f'},
-		'foo-bar': 'number'
+		'foo-bar': {type: 'number'}
 	}}
 );
 


### PR DESCRIPTION
This PR adds some type safety around `flags` and `unnormalizedFlags`.

```ts
meow({ flags: { foo: 'number' } }).flags.foo // number
meow({ flags: { foo: { type: 'string' } } }).flags.foo // string
meow({ flags: { 'foo-bar': 'boolean' } }).unnormalizedFlags['foo-bar'] // boolean
```

The following use cases remain untyped due to limitations in the current TS version (can't manipulate strings):

```ts
meow({ flags: { 'foo-bar': 'number' } }).flags.fooBar // unknown
meow({ flags: { foo: { type: 'string', alias: 'f' } }).unnormalizedFlags.f // unknown
```

The following use case gives the wrong type info (again because we can't manipulate strings):

```ts
meow({ flags: { 'foo-bar': 'number' } }).flags['foo-bar'] // number, but actually undefined
```

@sindresorhus do you think it's worth adding types for the rest of the use cases, or will the fragmented (and potentially wrong) type info confuse users?