### PR TITLE
Handle alias arrays generating unnormalized flags

### DIFF
--- a/index.js
+++ b/index.js
@@ -114,8 +114,15 @@ const meow = (helpText, options) => {
 
 	if (options.flags !== undefined) {
 		for (const flagValue of Object.values(options.flags)) {
-			delete flags[flagValue.alias];
+			if (Array.isArray(flagValue.alias)) {
+				flagValue.alias.forEach(alias =>
+					delete flags[flagValue.alias]
+				);
+			} else {
+				delete flags[flagValue.alias];
+			}
 		}
+
 	}
 
 	return {

--- a/index.js
+++ b/index.js
@@ -116,13 +116,12 @@ const meow = (helpText, options) => {
 		for (const flagValue of Object.values(options.flags)) {
 			if (Array.isArray(flagValue.alias)) {
 				flagValue.alias.forEach(alias =>
-					delete flags[flagValue.alias]
+					delete flags[alias]
 				);
 			} else {
 				delete flags[flagValue.alias];
 			}
 		}
-
 	}
 
 	return {


### PR DESCRIPTION
Minimist-options allows aliases to provided as an array. Until the introduction of `unnormalizedFlags` this did not cause any problems. The removal of aliases from the flag list silently fails if more than one alias is included for a particular flag.

Fixes #131