### PR TITLE
Replace `minimist-options` types with own ones

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -13,9 +13,9 @@ declare namespace meow {
 	type BooleanFlag = Flag<'boolean', boolean>;
 	type NumberFlag = Flag<'number', number>;
 
-	type BaseFlags = { [key: string]: StringFlag | BooleanFlag | NumberFlag };
+	type AnyFlags = { [key: string]: StringFlag | BooleanFlag | NumberFlag };
 
-	interface Options<Flags extends BaseFlags> {
+	interface Options<Flags extends AnyFlags> {
 		/**
 		Define argument flags.
 
@@ -172,7 +172,7 @@ declare namespace meow {
 		readonly hardRejection?: boolean;
 	}
 
-	type TypedFlags<Flags extends BaseFlags> = {
+	type TypedFlags<Flags extends AnyFlags> = {
 		[F in keyof Flags]: Flags[F] extends {type: 'number'}
 			? number
 			: Flags[F] extends {type: 'string'}
@@ -182,7 +182,7 @@ declare namespace meow {
 					: unknown;
 	};
 
-	interface Result<Flags extends BaseFlags> {
+	interface Result<Flags extends AnyFlags> {
 		/**
 		Non-flag arguments.
 		*/
@@ -259,7 +259,7 @@ const cli = meow(`
 foo(cli.input[0], cli.flags);
 ```
 */
-declare function meow<Flags extends meow.BaseFlags>(helpMessage: string, options?: meow.Options<Flags>): meow.Result<Flags>;
-declare function meow<Flags extends meow.BaseFlags>(options?: meow.Options<Flags>): meow.Result<Flags>;
+declare function meow<Flags extends meow.AnyFlags>(helpMessage: string, options?: meow.Options<Flags>): meow.Result<Flags>;
+declare function meow<Flags extends meow.AnyFlags>(options?: meow.Options<Flags>): meow.Result<Flags>;
 
 export = meow;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,8 +1,21 @@
 import {PackageJson} from 'type-fest';
-import {Options as MinimistOptions} from 'minimist-options';
 
 declare namespace meow {
-	interface Options<Flags extends MinimistOptions> {
+	type FlagType = 'string' | 'boolean' | 'number';
+
+	interface Flag<Type extends FlagType, Default> {
+		readonly type?: Type;
+		readonly alias?: string;
+		readonly default?: Default;
+	}
+
+	type StringFlag = Flag<'string', string>;
+	type BooleanFlag = Flag<'boolean', boolean>;
+	type NumberFlag = Flag<'number', number>;
+
+	type BaseFlags = { [key: string]: StringFlag | BooleanFlag | NumberFlag };
+
+	interface Options<Flags extends BaseFlags> {
 		/**
 		Define argument flags.
 
@@ -159,7 +172,7 @@ declare namespace meow {
 		readonly hardRejection?: boolean;
 	}
 
-	type TypedFlags<Flags extends MinimistOptions> = {
+	type TypedFlags<Flags extends BaseFlags> = {
 		[F in keyof Flags]: Flags[F] extends {type: 'number'}
 			? number
 			: Flags[F] extends {type: 'string'}
@@ -169,7 +182,7 @@ declare namespace meow {
 					: unknown;
 	};
 
-	interface Result<Flags extends MinimistOptions> {
+	interface Result<Flags extends BaseFlags> {
 		/**
 		Non-flag arguments.
 		*/
@@ -246,7 +259,7 @@ const cli = meow(`
 foo(cli.input[0], cli.flags);
 ```
 */
-declare function meow<Flags extends MinimistOptions>(helpMessage: string, options?: meow.Options<Flags>): meow.Result<Flags>;
-declare function meow<Flags extends MinimistOptions>(options?: meow.Options<Flags>): meow.Result<Flags>;
+declare function meow<Flags extends meow.BaseFlags>(helpMessage: string, options?: meow.Options<Flags>): meow.Result<Flags>;
+declare function meow<Flags extends meow.BaseFlags>(options?: meow.Options<Flags>): meow.Result<Flags>;
 
 export = meow;

--- a/index.d.ts
+++ b/index.d.ts
@@ -13,7 +13,7 @@ declare namespace meow {
 	type BooleanFlag = Flag<'boolean', boolean>;
 	type NumberFlag = Flag<'number', number>;
 
-	type AnyFlags = { [key: string]: StringFlag | BooleanFlag | NumberFlag };
+	type AnyFlags = {[key: string]: StringFlag | BooleanFlag | NumberFlag};
 
 	interface Options<Flags extends AnyFlags> {
 		/**

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -33,7 +33,8 @@ expectType<Result<never>>(meow({hardRejection: false}));
 const result = meow('Help text', {
 	flags: {
 		foo: {type: 'boolean', alias: 'f'},
-		'foo-bar': {type: 'number'}
+		'foo-bar': {type: 'number'},
+		bar: {type: 'string', default: ''}
 	}}
 );
 
@@ -42,10 +43,12 @@ expectType<PackageJson>(result.pkg);
 expectType<string>(result.help);
 
 expectType<boolean>(result.flags.foo);
+expectType<unknown>(result.flags.fooBar);
+expectType<string>(result.flags.bar);
 expectType<boolean>(result.unnormalizedFlags.foo);
 expectType<unknown>(result.unnormalizedFlags.f);
 expectType<number>(result.unnormalizedFlags['foo-bar']);
-expectType<unknown>(result.flags.fooBar);
+expectType<string>(result.unnormalizedFlags.bar);
 
 result.showHelp();
 result.showHelp(1);


### PR DESCRIPTION
Fix #134

See also:

https://github.com/vadimdemedes/minimist-options/blob/f6d24087f871d6605b6c8d0f9c2b36af18467875/index.d.ts