### PR TITLE
Update `yargs-parser` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
 		"redent": "^3.0.0",
 		"trim-newlines": "^3.0.0",
 		"type-fest": "^0.8.1",
-		"yargs-parser": "^16.1.0"
+		"yargs-parser": "^18.1.1"
 	},
 	"devDependencies": {
 		"ava": "^2.4.0",


### PR DESCRIPTION
[yargs-parser v18.1.1](https://github.com/yargs/yargs-parser/releases/tag/v18.1.1) fixes a prototype pollution vulnerability:

```
? ✗ Medium severity vuln found in yargs-parser@16.1.0, introduced via meow@6.0.1
    Description: Prototype Pollution
    Info: https://snyk.io/vuln/SNYK-JS-YARGSPARSER-560381
    From: meow@6.0.1 > yargs-parser@16.1.0
```

https://app.snyk.io/vuln/SNYK-JS-YARGSPARSER-560381
https://github.com/yargs/yargs-parser/pull/258

Thanks! 😊