### PR TITLE
Add `isMultiple` option for flags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 yarn.lock
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 node_modules
 yarn.lock
-.vscode

--- a/index.d.ts
+++ b/index.d.ts
@@ -177,12 +177,12 @@ declare namespace meow {
 
 	type TypedFlags<Flags extends AnyFlags> = {
 		[F in keyof Flags]: Flags[F] extends {type: 'number'}
-		? number
-		: Flags[F] extends {type: 'string'}
-		? string
-		: Flags[F] extends {type: 'boolean'}
-		? boolean
-		: unknown;
+			? number
+			: Flags[F] extends {type: 'string'}
+				? string
+				: Flags[F] extends {type: 'boolean'}
+					? boolean
+					: unknown;
 	};
 
 	interface Result<Flags extends AnyFlags> {

--- a/index.d.ts
+++ b/index.d.ts
@@ -25,7 +25,7 @@ declare namespace meow {
 		- `type`: Type of value. (Possible values: `string` `boolean` `number`)
 		- `alias`: Usually used to define a short flag alias.
 		- `default`: Default value when the flag is not specified.
-		- `multiple`: Indicates a flag can be set multiple times. Returns an array. (Default: false)
+		- `multiple`: Indicates a flag can be set multiple times. Values are turned into an array. (Default: false)
 
 		@example
 		```
@@ -177,12 +177,12 @@ declare namespace meow {
 
 	type TypedFlags<Flags extends AnyFlags> = {
 		[F in keyof Flags]: Flags[F] extends {type: 'number'}
-			? number
-			: Flags[F] extends {type: 'string'}
-				? string
-				: Flags[F] extends {type: 'boolean'}
-					? boolean
-					: unknown;
+		? number
+		: Flags[F] extends {type: 'string'}
+		? string
+		: Flags[F] extends {type: 'boolean'}
+		? boolean
+		: unknown;
 	};
 
 	interface Result<Flags extends AnyFlags> {

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,6 +7,7 @@ declare namespace meow {
 		readonly type?: Type;
 		readonly alias?: string;
 		readonly default?: Default;
+		readonly multiple?: boolean;
 	}
 
 	type StringFlag = Flag<'string', string>;
@@ -24,6 +25,7 @@ declare namespace meow {
 		- `type`: Type of value. (Possible values: `string` `boolean` `number`)
 		- `alias`: Usually used to define a short flag alias.
 		- `default`: Default value when the flag is not specified.
+		- `multiple`: Indicates a flag can be set multiple times. Returns an array. (Default: false)
 
 		@example
 		```
@@ -31,7 +33,8 @@ declare namespace meow {
 			unicorn: {
 				type: 'string',
 				alias: 'u',
-				default: 'rainbow'
+				default: ['rainbow', 'cat'],
+				multiple: true
 			}
 		}
 		```

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,7 +7,7 @@ declare namespace meow {
 		readonly type?: Type;
 		readonly alias?: string;
 		readonly default?: Default;
-		readonly multiple?: boolean;
+		readonly isMultiple?: boolean;
 	}
 
 	type StringFlag = Flag<'string', string>;
@@ -25,7 +25,7 @@ declare namespace meow {
 		- `type`: Type of value. (Possible values: `string` `boolean` `number`)
 		- `alias`: Usually used to define a short flag alias.
 		- `default`: Default value when the flag is not specified.
-		- `multiple`: Indicates a flag can be set multiple times. Values are turned into an array. (Default: false)
+		- `isMultiple`: Indicates a flag can be set multiple times. Values are turned into an array. (Default: false)
 
 		@example
 		```
@@ -34,7 +34,7 @@ declare namespace meow {
 				type: 'string',
 				alias: 'u',
 				default: ['rainbow', 'cat'],
-				multiple: true
+				isMultiple: true
 			}
 		}
 		```

--- a/index.js
+++ b/index.js
@@ -64,35 +64,35 @@ const meow = (helpText, options) => {
 		return flags;
 	}, {});
 
-	let minimistOptions = {
+	let minimistoptions = {
 		arguments: options.input,
 		...minimistFlags
 	};
 
-	minimistOptions = decamelizeKeys(minimistOptions, '-', {exclude: ['stopEarly', '--']});
+	minimistoptions = decamelizeKeys(minimistoptions, '-', {exclude: ['stopEarly', '--']});
 
 	if (options.inferType) {
-		delete minimistOptions.arguments;
+		delete minimistoptions.arguments;
 	}
 
-	minimistOptions = buildMinimistOptions(minimistOptions);
+	minimistoptions = buildMinimistOptions(minimistoptions);
 
-	if (minimistOptions['--']) {
-		minimistOptions.configuration = {
-			...minimistOptions.configuration,
+	if (minimistoptions['--']) {
+		minimistoptions.configuration = {
+			...minimistoptions.configuration,
 			'populate--': true
 		};
 	}
 
-	if (minimistOptions.array !== undefined) {
-		minimistOptions.array = arrify(minimistOptions.array).map(flagKey => ({
+	if (minimistoptions.array !== undefined) {
+		minimistoptions.array = arrify(minimistoptions.array).map(flagKey => ({
 			key: flagKey,
 			[options.flags[flagKey].type || 'string']: true
 		}));
 	}
 
 	const {pkg} = options;
-	const argv = yargs(options.argv, minimistOptions);
+	const argv = yargs(options.argv, minimistoptions);
 	let help = redent(trimNewlines((options.help || '').replace(/\t+\n*$/, '')), 2);
 
 	normalizePackageData(pkg);

--- a/index.js
+++ b/index.js
@@ -134,7 +134,7 @@ const meow = (helpText, options) => {
 
 	for (const [flagKey, flagValue] of Object.entries(options.flags).filter(([key]) => key !== '--')) {
 		if (!flagValue.multiple && Array.isArray(flags[flagKey])) {
-			throw new Error(`Only one value allowed for --${flagKey}.`);
+			throw new Error(`The flag --${flagKey} can only be set once.`);
 		}
 
 		delete flags[flagValue.alias];

--- a/index.js
+++ b/index.js
@@ -38,9 +38,8 @@ const buildParserFlags = ({flags, booleanDefault}) =>
 	}, {});
 
 /**
- * Convert to alternative syntax for coercing values to expected type,
- * according to https://github.com/yargs/yargs-parser#requireyargs-parserargs-opts.
- */
+Convert to alternative syntax for coercing values to expected type, according to https://github.com/yargs/yargs-parser#requireyargs-parserargs-opts.
+*/
 const convertToTypedArrayOption = (arrayOption, flags) =>
 	arrify(arrayOption).map(flagKey => ({
 		key: flagKey,

--- a/index.js
+++ b/index.js
@@ -24,12 +24,12 @@ const buildMinimistFlags = ({flags, booleanDefault}) =>
 			flag.type === 'boolean' &&
 			!Object.prototype.hasOwnProperty.call(flag, 'default')
 		) {
-			flag.default = flag.multiple ? [booleanDefault] : booleanDefault;
+			flag.default = flag.isMultiple ? [booleanDefault] : booleanDefault;
 		}
 
-		if (flag.multiple) {
+		if (flag.isMultiple) {
 			flag.type = 'array';
-			delete flag.multiple;
+			delete flag.isMultiple;
 		}
 
 		minimistFlags[flagKey] = flag;
@@ -49,7 +49,7 @@ const convertToTypedArrayOption = (arrayOption, flags) =>
 
 const validateFlags = (flags, options) => {
 	for (const [flagKey, flagValue] of Object.entries(options.flags)) {
-		if (flagKey !== '--' && !flagValue.multiple && Array.isArray(flags[flagKey])) {
+		if (flagKey !== '--' && !flagValue.isMultiple && Array.isArray(flags[flagKey])) {
 			throw new Error(`The flag --${flagKey} can only be set once.`);
 		}
 	}

--- a/index.js
+++ b/index.js
@@ -85,6 +85,11 @@ const meow = (helpText, options) => {
 	}
 
 	if (minimistOptions.array !== undefined) {
+		// `yargs` supports 'string|number|boolean' arrays,
+		// but `minimist-options` only support 'string' as element type.
+		// Convert to alternative syntax for coercing values to expected type,
+		// according to https://github.com/yargs/yargs-parser#requireyargs-parserargs-opts
+		// Open issue to add support to `minimist-options`: https://github.com/vadimdemedes/minimist-options/issues/18
 		minimistOptions.array = arrify(minimistOptions.array).map(flagKey => ({
 			key: flagKey,
 			[options.flags[flagKey].type || 'string']: true

--- a/index.js
+++ b/index.js
@@ -84,8 +84,8 @@ const meow = (helpText, options) => {
 		};
 	}
 
-	if (minimistoptions.array !== undefined) {
-		minimistoptions.array = arrify(minimistoptions.array).map(flagKey => ({
+	if (minimistOptions.array !== undefined) {
+		minimistOptions.array = arrify(minimistOptions.array).map(flagKey => ({
 			key: flagKey,
 			[options.flags[flagKey].type || 'string']: true
 		}));

--- a/index.js
+++ b/index.js
@@ -134,7 +134,7 @@ const meow = (helpText, options) => {
 
 	for (const [flagKey, flagValue] of Object.entries(options.flags).filter(([key]) => key !== '--')) {
 		if (!flagValue.multiple && Array.isArray(flags[flagKey])) {
-			throw new Error(`Only one value allowed for --${flagKey}.`)
+			throw new Error(`Only one value allowed for --${flagKey}.`);
 		}
 
 		delete flags[flagValue.alias];

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -35,8 +35,8 @@ const result = meow('Help text', {
 		foo: {type: 'boolean', alias: 'f'},
 		'foo-bar': {type: 'number'},
 		bar: {type: 'string', default: ''}
-	}}
-);
+	}
+});
 
 expectType<string[]>(result.input);
 expectType<PackageJson>(result.pkg);

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
 	],
 	"dependencies": {
 		"@types/minimist": "^1.2.0",
+		"arrify": "^2.0.1",
 		"camelcase-keys": "^6.1.1",
 		"decamelize-keys": "^1.1.0",
 		"hard-rejection": "^2.0.0",

--- a/readme.md
+++ b/readme.md
@@ -97,7 +97,7 @@ The key is the flag name and the value is an object with any of:
 - `type`: Type of value. (Possible values: `string` `boolean` `number`)
 - `alias`: Usually used to define a short flag alias.
 - `default`: Default value when the flag is not specified.
-- `multiple`: Indicates a flag can be set multiple times. Returns an array. (Default: false)
+- `multiple`: Indicates a flag can be set multiple times. Values are turned into an array. (Default: false)
 
 Example:
 

--- a/readme.md
+++ b/readme.md
@@ -97,6 +97,7 @@ The key is the flag name and the value is an object with any of:
 - `type`: Type of value. (Possible values: `string` `boolean` `number`)
 - `alias`: Usually used to define a short flag alias.
 - `default`: Default value when the flag is not specified.
+- `multiple`: Indicates a flag can be set multiple times. Returns an array. (Default: false)
 
 Example:
 
@@ -105,7 +106,8 @@ flags: {
 	unicorn: {
 		type: 'string',
 		alias: 'u',
-		default: 'rainbow'
+		default: ['rainbow', 'cat'],
+		multiple: true
 	}
 }
 ```

--- a/readme.md
+++ b/readme.md
@@ -97,7 +97,7 @@ The key is the flag name and the value is an object with any of:
 - `type`: Type of value. (Possible values: `string` `boolean` `number`)
 - `alias`: Usually used to define a short flag alias.
 - `default`: Default value when the flag is not specified.
-- `multiple`: Indicates a flag can be set multiple times. Values are turned into an array. (Default: false)
+- `isMultiple`: Indicates a flag can be set multiple times. Values are turned into an array. (Default: false)
 
 Example:
 
@@ -107,7 +107,7 @@ flags: {
 		type: 'string',
 		alias: 'u',
 		default: ['rainbow', 'cat'],
-		multiple: true
+		isMultiple: true
 	}
 }
 ```

--- a/test.js
+++ b/test.js
@@ -314,7 +314,7 @@ test('multiple flag set once returns array', t => {
 		flags: {
 			foo: {
 				type: 'string',
-				multiple: true
+				isMultiple: true
 			}
 		}
 	}).flags, {
@@ -328,7 +328,7 @@ test('multiple flag set multiple times', t => {
 		flags: {
 			foo: {
 				type: 'string',
-				multiple: true
+				isMultiple: true
 			}
 		}
 	}).flags, {
@@ -342,7 +342,7 @@ test('multiple flag with space separated values', t => {
 		flags: {
 			foo: {
 				type: 'string',
-				multiple: true
+				isMultiple: true
 			}
 		}
 	}).flags, {
@@ -369,7 +369,7 @@ test('multiple boolean flag', t => {
 		flags: {
 			foo: {
 				type: 'boolean',
-				multiple: true
+				isMultiple: true
 			}
 		}
 	}).flags, {
@@ -383,7 +383,7 @@ test('multiple boolean flag is false by default', t => {
 		flags: {
 			foo: {
 				type: 'boolean',
-				multiple: true
+				isMultiple: true
 			}
 		}
 	}).flags, {
@@ -398,11 +398,11 @@ test('multiple flag with `booleanDefault: undefined` => filter out unset boolean
 		flags: {
 			foo: {
 				type: 'boolean',
-				multiple: true
+				isMultiple: true
 			},
 			bar: {
 				type: 'boolean',
-				multiple: true
+				isMultiple: true
 			}
 		}
 	}).flags, {
@@ -416,7 +416,7 @@ test('multiple number flag', t => {
 		flags: {
 			foo: {
 				type: 'number',
-				multiple: true
+				isMultiple: true
 			}
 		}
 	}).flags, {
@@ -430,17 +430,17 @@ test('multiple flag default values', t => {
 		flags: {
 			string: {
 				type: 'string',
-				multiple: true,
+				isMultiple: true,
 				default: ['foo']
 			},
 			boolean: {
 				type: 'boolean',
-				multiple: true,
+				isMultiple: true,
 				default: [true]
 			},
 			number: {
 				type: 'number',
-				multiple: true,
+				isMultiple: true,
 				default: [0.5]
 			}
 		}

--- a/test.js
+++ b/test.js
@@ -450,3 +450,30 @@ test('isMultiple - flag default values', t => {
 		number: [0.5]
 	});
 });
+
+test('isMultiple - multiple flag default values', t => {
+	t.deepEqual(meow({
+		argv: [],
+		flags: {
+			string: {
+				type: 'string',
+				isMultiple: true,
+				default: ['foo', 'bar']
+			},
+			boolean: {
+				type: 'boolean',
+				isMultiple: true,
+				default: [true, false]
+			},
+			number: {
+				type: 'number',
+				isMultiple: true,
+				default: [0.5, 1]
+			}
+		}
+	}).flags, {
+		string: ['foo', 'bar'],
+		boolean: [true, false],
+		number: [0.5, 1]
+	});
+});

--- a/test.js
+++ b/test.js
@@ -308,7 +308,7 @@ test('supports `number` flag type - throws on incorrect default value', t => {
 	});
 });
 
-test('multiple flag set once returns array', t => {
+test('isMultiple - flag set once returns array', t => {
 	t.deepEqual(meow({
 		argv: ['--foo=bar'],
 		flags: {
@@ -322,7 +322,7 @@ test('multiple flag set once returns array', t => {
 	});
 });
 
-test('multiple flag set multiple times', t => {
+test('isMultiple - flag set multiple times', t => {
 	t.deepEqual(meow({
 		argv: ['--foo=bar', '--foo=baz'],
 		flags: {
@@ -336,7 +336,7 @@ test('multiple flag set multiple times', t => {
 	});
 });
 
-test('multiple flag with space separated values', t => {
+test('isMultiple - flag with space separated values', t => {
 	t.deepEqual(meow({
 		argv: ['--foo', 'bar', 'baz'],
 		flags: {
@@ -363,7 +363,7 @@ test('single flag set more than once => throws', t => {
 	}, {message: 'The flag --foo can only be set once.'});
 });
 
-test('multiple boolean flag', t => {
+test('isMultiple - boolean flag', t => {
 	t.deepEqual(meow({
 		argv: ['--foo', '--foo=false'],
 		flags: {
@@ -377,7 +377,7 @@ test('multiple boolean flag', t => {
 	});
 });
 
-test('multiple boolean flag is false by default', t => {
+test('isMultiple - boolean flag is false by default', t => {
 	t.deepEqual(meow({
 		argv: [],
 		flags: {
@@ -391,7 +391,7 @@ test('multiple boolean flag is false by default', t => {
 	});
 });
 
-test('multiple flag with `booleanDefault: undefined` => filter out unset boolean args', t => {
+test('isMultiple - flag with `booleanDefault: undefined` => filter out unset boolean args', t => {
 	t.deepEqual(meow({
 		argv: ['--foo'],
 		booleanDefault: undefined,
@@ -410,7 +410,7 @@ test('multiple flag with `booleanDefault: undefined` => filter out unset boolean
 	});
 });
 
-test('multiple number flag', t => {
+test('isMultiple - number flag', t => {
 	t.deepEqual(meow({
 		argv: ['--foo=1.3', '--foo=-1'],
 		flags: {
@@ -424,7 +424,7 @@ test('multiple number flag', t => {
 	});
 });
 
-test('multiple flag default values', t => {
+test('isMultiple - flag default values', t => {
 	t.deepEqual(meow({
 		argv: [],
 		flags: {

--- a/test.js
+++ b/test.js
@@ -360,7 +360,7 @@ test('single flag set more than once => throws', t => {
 				}
 			}
 		});
-	}, {message: 'Only one value allowed for --foo.'});
+	}, {message: 'The flag --foo can only be set once.'});
 });
 
 test('multiple boolean flag', t => {

--- a/test.js
+++ b/test.js
@@ -307,3 +307,146 @@ test('supports `number` flag type - throws on incorrect default value', t => {
 		});
 	});
 });
+
+test('multiple flag set once returns array', t => {
+	t.deepEqual(meow({
+		argv: ['--foo=bar'],
+		flags: {
+			foo: {
+				type: 'string',
+				multiple: true
+			}
+		}
+	}).flags, {
+		foo: ['bar']
+	});
+});
+
+test('multiple flag set multiple times', t => {
+	t.deepEqual(meow({
+		argv: ['--foo=bar', '--foo=baz'],
+		flags: {
+			foo: {
+				type: 'string',
+				multiple: true
+			}
+		}
+	}).flags, {
+		foo: ['bar', 'baz']
+	});
+});
+
+test('multiple flag with space separated values', t => {
+	t.deepEqual(meow({
+		argv: ['--foo', 'bar', 'baz'],
+		flags: {
+			foo: {
+				type: 'string',
+				multiple: true
+			}
+		}
+	}).flags, {
+		foo: ['bar', 'baz']
+	});
+});
+
+test('single flag set more than once => throws', t => {
+	t.throws(() => {
+		meow({
+			argv: ['--foo=bar', '--foo=baz'],
+			flags: {
+				foo: {
+					type: 'string'
+				}
+			}
+		});
+	}, {message: 'Only one value allowed for --foo.'});
+});
+
+test('multiple boolean flag', t => {
+	t.deepEqual(meow({
+		argv: ['--foo', '--foo=false'],
+		flags: {
+			foo: {
+				type: 'boolean',
+				multiple: true
+			}
+		}
+	}).flags, {
+		foo: [true, false]
+	});
+});
+
+test('multiple boolean flag is false by default', t => {
+	t.deepEqual(meow({
+		argv: [],
+		flags: {
+			foo: {
+				type: 'boolean',
+				multiple: true
+			}
+		}
+	}).flags, {
+		foo: [false]
+	});
+});
+
+test('multiple flag with `booleanDefault: undefined` => filter out unset boolean args', t => {
+	t.deepEqual(meow({
+		argv: ['--foo'],
+		booleanDefault: undefined,
+		flags: {
+			foo: {
+				type: 'boolean',
+				multiple: true
+			},
+			bar: {
+				type: 'boolean',
+				multiple: true
+			}
+		}
+	}).flags, {
+		foo: [true]
+	});
+});
+
+test('multiple number flag', t => {
+	t.deepEqual(meow({
+		argv: ['--foo=1.3', '--foo=-1'],
+		flags: {
+			foo: {
+				type: 'number',
+				multiple: true
+			}
+		}
+	}).flags, {
+		foo: [1.3, -1]
+	});
+});
+
+test('multiple flag default values', t => {
+	t.deepEqual(meow({
+		argv: [],
+		flags: {
+			string: {
+				type: 'string',
+				multiple: true,
+				default: ['foo']
+			},
+			boolean: {
+				type: 'boolean',
+				multiple: true,
+				default: [true]
+			},
+			number: {
+				type: 'number',
+				multiple: true,
+				default: [0.5]
+			}
+		}
+	}).flags, {
+		string: ['foo'],
+		boolean: [true],
+		number: [0.5]
+	});
+});


### PR DESCRIPTION
Differs in two ways from previous attempts:

1. Instead of setting the last value if a flag is used multiple times without `multiple` set, it throws an error. Makes more sense to me and is how I interpret _"we should **allow** only one value by default"_.
2. It supports `boolean` and `number` arrays in addition to `string`.

Fixes #111
Closes #123