### PR TITLE
fix: update yargs-parser to 18.1.2 to fix "vulnerability" in 18.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
 		"redent": "^3.0.0",
 		"trim-newlines": "^3.0.0",
 		"type-fest": "^0.8.1",
-		"yargs-parser": "^18.1.1"
+		"yargs-parser": "^18.1.2"
 	},
 	"devDependencies": {
 		"ava": "^2.4.0",


### PR DESCRIPTION
"fixes" a low-impact security vulnerability introduces by yargs-parser as asserted by npm audit.

ref: https://www.npmjs.com/advisories/1500