### PR TITLE
Remove type coercion patch

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@
 const path = require('path');
 const buildParserOptions = require('minimist-options');
 const parseArguments = require('yargs-parser');
-const camelCase = require('camelcase');
 const camelCaseKeys = require('camelcase-keys');
 const decamelizeKeys = require('decamelize-keys');
 const trimNewlines = require('trim-newlines');
@@ -10,7 +9,6 @@ const redent = require('redent');
 const readPkgUp = require('read-pkg-up');
 const hardRejection = require('hard-rejection');
 const normalizePackageData = require('normalize-package-data');
-const arrify = require('arrify');
 
 // Prevent caching of this module so module.parent is always accurate
 delete require.cache[__filename];
@@ -69,7 +67,7 @@ const buildParserFlags = ({flags, booleanDefault}) =>
 		}
 
 		if (flag.isMultiple) {
-			flag.type = 'array';
+			flag.type = flag.type ? `${flag.type}-array` : 'array';
 			delete flag.isMultiple;
 		}
 
@@ -77,15 +75,6 @@ const buildParserFlags = ({flags, booleanDefault}) =>
 
 		return parserFlags;
 	}, {});
-
-/**
-Convert to alternative syntax for coercing values to expected type, according to https://github.com/yargs/yargs-parser#requireyargs-parserargs-opts.
-*/
-const convertToTypedArrayOption = (arrayOption, flags) =>
-	arrify(arrayOption).map(flagKey => ({
-		key: flagKey,
-		[flags[camelCase(flagKey, '-')].type || 'string']: true
-	}));
 
 const validateFlags = (flags, options) => {
 	for (const [flagKey, flagValue] of Object.entries(options.flags)) {
@@ -140,13 +129,6 @@ const meow = (helpText, options) => {
 			...parserOptions.configuration,
 			'populate--': true
 		};
-	}
-
-	if (parserOptions.array !== undefined) {
-		// `yargs` supports 'string|number|boolean' arrays,
-		// but `minimist-options` only support 'string' as element type.
-		// Open issue to add support to `minimist-options`: https://github.com/vadimdemedes/minimist-options/issues/18.
-		parserOptions.array = convertToTypedArrayOption(parserOptions.array, options.flags);
 	}
 
 	const {pkg} = options;

--- a/package.json
+++ b/package.json
@@ -41,12 +41,10 @@
 	],
 	"dependencies": {
 		"@types/minimist": "^1.2.0",
-		"arrify": "^2.0.1",
-		"camelcase": "^6.0.0",
 		"camelcase-keys": "^6.2.2",
 		"decamelize-keys": "^1.1.0",
 		"hard-rejection": "^2.1.0",
-		"minimist-options": "^4.0.2",
+		"minimist-options": "4.1.0",
 		"normalize-package-data": "^2.5.0",
 		"read-pkg-up": "^7.0.1",
 		"redent": "^3.0.0",

--- a/test/test.js
+++ b/test/test.js
@@ -367,6 +367,19 @@ test('single flag set more than once => throws', t => {
 	}, {message: 'The flag --foo can only be set once.'});
 });
 
+test('isMultiple - default to type string', t => {
+	t.deepEqual(meow({
+		argv: ['--foo=bar'],
+		flags: {
+			foo: {
+				isMultiple: true
+			}
+		}
+	}).flags, {
+		foo: ['bar']
+	});
+});
+
 test('isMultiple - boolean flag', t => {
 	t.deepEqual(meow({
 		argv: ['--foo', '--foo=false'],


### PR DESCRIPTION
As https://github.com/vadimdemedes/minimist-options/issues/18 is now closed, we no longer need to patch the output from `minimist-options` to coerce types before passing it to `yargs-parser`.