### PR TITLE
Improve flags types to acknowledge `isMultiple` and `isRequired` options

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -205,17 +205,17 @@ declare namespace meow {
 					? boolean
 					: unknown;
 
-	type PossiblyOptionalFlag<Flag extends AnyFlag> =
+	type PossiblyOptionalFlag<Flag extends AnyFlag, FlagType> =
 		Flag extends {isRequired: true}
-			? TypedFlag<Flag>
+			? FlagType
 			: Flag extends {default: any}
-				? TypedFlag<Flag>
-				: TypedFlag<Flag>|undefined;
+				? FlagType
+				: FlagType|undefined;
 
 	type TypedFlags<Flags extends AnyFlags> = {
 		[F in keyof Flags]: Flags[F] extends {isMultiple: true}
-			? Array<TypedFlag<Flags[F]>>
-			: PossiblyOptionalFlag<Flags[F]>
+			? PossiblyOptionalFlag<Flags[F], Array<TypedFlag<Flags[F]>>>
+			: PossiblyOptionalFlag<Flags[F], TypedFlag<Flags[F]>>
 	};
 
 	interface Result<Flags extends AnyFlags> {

--- a/index.d.ts
+++ b/index.d.ts
@@ -25,7 +25,8 @@ declare namespace meow {
 	type BooleanFlag = Flag<'boolean', boolean>;
 	type NumberFlag = Flag<'number', number>;
 
-	type AnyFlags = {[key: string]: StringFlag | BooleanFlag | NumberFlag};
+  type AnyFlag = StringFlag | BooleanFlag | NumberFlag;
+	type AnyFlags = {[key: string]: AnyFlag};
 
 	interface Options<Flags extends AnyFlags> {
 		/**
@@ -195,14 +196,26 @@ declare namespace meow {
 		readonly hardRejection?: boolean;
 	}
 
-	type TypedFlags<Flags extends AnyFlags> = {
-		[F in keyof Flags]: Flags[F] extends {type: 'number'}
+	type TypedFlag<Flag extends AnyFlag> =
+		Flag extends {type: 'number'}
 			? number
-			: Flags[F] extends {type: 'string'}
+			: Flag extends {type: 'string'}
 				? string
-				: Flags[F] extends {type: 'boolean'}
+				: Flag extends {type: 'boolean'}
 					? boolean
 					: unknown;
+
+	type PossiblyOptionalFlag<Flag extends AnyFlag> =
+		Flag extends {isRequired: true}
+			? TypedFlag<Flag>
+			: Flag extends {default: any}
+				? TypedFlag<Flag>
+				: TypedFlag<Flag>|undefined;
+
+	type TypedFlags<Flags extends AnyFlags> = {
+		[F in keyof Flags]: Flags[F] extends {isMultiple: true}
+			? Array<TypedFlag<Flags[F]>>
+			: PossiblyOptionalFlag<Flags[F]>
 	};
 
 	interface Result<Flags extends AnyFlags> {

--- a/index.d.ts
+++ b/index.d.ts
@@ -25,7 +25,7 @@ declare namespace meow {
 	type BooleanFlag = Flag<'boolean', boolean>;
 	type NumberFlag = Flag<'number', number>;
 
-  type AnyFlag = StringFlag | BooleanFlag | NumberFlag;
+	type AnyFlag = StringFlag | BooleanFlag | NumberFlag;
 	type AnyFlags = {[key: string]: AnyFlag};
 
 	interface Options<Flags extends AnyFlags> {
@@ -210,7 +210,7 @@ declare namespace meow {
 			? FlagType
 			: Flag extends {default: any}
 				? FlagType
-				: FlagType|undefined;
+				: FlagType | undefined;
 
 	type TypedFlags<Flags extends AnyFlags> = {
 		[F in keyof Flags]: Flags[F] extends {isMultiple: true}

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -55,12 +55,12 @@ expectType<string>(result.help);
 expectType<boolean | undefined>(result.flags.foo);
 expectType<unknown>(result.flags.fooBar);
 expectType<string>(result.flags.bar);
-expectType<string[]>(result.flags.abc);
+expectType<string[] | undefined>(result.flags.abc);
 expectType<boolean | undefined>(result.unnormalizedFlags.foo);
 expectType<unknown>(result.unnormalizedFlags.f);
 expectType<number | undefined>(result.unnormalizedFlags['foo-bar']);
 expectType<string>(result.unnormalizedFlags.bar);
-expectType<string[]>(result.unnormalizedFlags.abc);
+expectType<string[] | undefined>(result.unnormalizedFlags.abc);
 
 result.showHelp();
 result.showHelp(1);

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -14,13 +14,13 @@ expectAssignable<{flags: {foo: string}}>(
 expectAssignable<{flags: {foo: boolean}}>(
 	meow({flags: {foo: {type: 'boolean', isRequired: true}}})
 );
-expectAssignable<{flags: {foo: number|undefined}}>(
+expectAssignable<{flags: {foo: number | undefined}}>(
 	meow({flags: {foo: {type: 'number'}}})
 );
-expectAssignable<{flags: {foo: string|undefined}}>(
+expectAssignable<{flags: {foo: string | undefined}}>(
 	meow({flags: {foo: {type: 'string'}}})
 );
-expectAssignable<{flags: {foo: boolean|undefined}}>(
+expectAssignable<{flags: {foo: boolean | undefined}}>(
 	meow({flags: {foo: {type: 'boolean'}}})
 );
 expectType<Result<never>>(meow({description: 'foo'}));
@@ -52,13 +52,13 @@ expectType<string[]>(result.input);
 expectType<PackageJson>(result.pkg);
 expectType<string>(result.help);
 
-expectType<boolean|undefined>(result.flags.foo);
+expectType<boolean | undefined>(result.flags.foo);
 expectType<unknown>(result.flags.fooBar);
 expectType<string>(result.flags.bar);
 expectType<string[]>(result.flags.abc);
-expectType<boolean|undefined>(result.unnormalizedFlags.foo);
+expectType<boolean | undefined>(result.unnormalizedFlags.foo);
 expectType<unknown>(result.unnormalizedFlags.f);
-expectType<number|undefined>(result.unnormalizedFlags['foo-bar']);
+expectType<number | undefined>(result.unnormalizedFlags['foo-bar']);
 expectType<string>(result.unnormalizedFlags.bar);
 expectType<string[]>(result.unnormalizedFlags.abc);
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -6,12 +6,21 @@ import {Result} from '.';
 expectType<Result<never>>(meow('Help text'));
 expectType<Result<never>>(meow('Help text', {hardRejection: false}));
 expectAssignable<{flags: {foo: number}}>(
-	meow({flags: {foo: {type: 'number'}}})
+	meow({flags: {foo: {type: 'number', isRequired: true}}})
 );
 expectAssignable<{flags: {foo: string}}>(
-	meow({flags: {foo: {type: 'string'}}})
+	meow({flags: {foo: {type: 'string', isRequired: true}}})
 );
 expectAssignable<{flags: {foo: boolean}}>(
+	meow({flags: {foo: {type: 'boolean', isRequired: true}}})
+);
+expectAssignable<{flags: {foo: number|undefined}}>(
+	meow({flags: {foo: {type: 'number'}}})
+);
+expectAssignable<{flags: {foo: string|undefined}}>(
+	meow({flags: {foo: {type: 'string'}}})
+);
+expectAssignable<{flags: {foo: boolean|undefined}}>(
 	meow({flags: {foo: {type: 'boolean'}}})
 );
 expectType<Result<never>>(meow({description: 'foo'}));
@@ -34,7 +43,8 @@ const result = meow('Help text', {
 	flags: {
 		foo: {type: 'boolean', alias: 'f'},
 		'foo-bar': {type: 'number'},
-		bar: {type: 'string', default: ''}
+		bar: {type: 'string', default: ''},
+		abc: {type: 'string', isMultiple: true}
 	}
 });
 
@@ -42,13 +52,15 @@ expectType<string[]>(result.input);
 expectType<PackageJson>(result.pkg);
 expectType<string>(result.help);
 
-expectType<boolean>(result.flags.foo);
+expectType<boolean|undefined>(result.flags.foo);
 expectType<unknown>(result.flags.fooBar);
 expectType<string>(result.flags.bar);
-expectType<boolean>(result.unnormalizedFlags.foo);
+expectType<string[]>(result.flags.abc);
+expectType<boolean|undefined>(result.unnormalizedFlags.foo);
 expectType<unknown>(result.unnormalizedFlags.f);
-expectType<number>(result.unnormalizedFlags['foo-bar']);
+expectType<number|undefined>(result.unnormalizedFlags['foo-bar']);
 expectType<string>(result.unnormalizedFlags.bar);
+expectType<string[]>(result.unnormalizedFlags.abc);
 
 result.showHelp();
 result.showHelp(1);

--- a/test/test.js
+++ b/test/test.js
@@ -510,6 +510,17 @@ test('isMultiple - handles multi-word flag name', t => {
 	});
 });
 
+test('isMultiple - handles non-set flags correctly', t => {
+	t.deepEqual(meow({
+		argv: [],
+		flags: {
+			foo: {
+				isMultiple: true
+			}
+		}
+	}).flags, {});
+});
+
 if (NODE_MAJOR_VERSION >= 14) {
 	test('supports es modules', async t => {
 		try {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "files": [
+    "index.d.ts",
+    "index.test-d.ts",
+  ],
+  "compilerOptions": {
+    "strict": true,
+    "jsx": "react",
+    "target": "es2017",
+    "lib": ["es2017"],
+    "module": "commonjs",
+    "moduleResolution": "node",
+
+    /* Strict Type-Checking Options */
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+
+    /* Additional Checks */
+    "noUnusedLocals": true
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,21 +1,19 @@
 {
-  "files": [
-    "index.d.ts",
-    "index.test-d.ts",
-  ],
-  "compilerOptions": {
-    "strict": true,
-    "jsx": "react",
-    "target": "es2017",
-    "lib": ["es2017"],
-    "module": "commonjs",
-    "moduleResolution": "node",
-
-    /* Strict Type-Checking Options */
-    "noImplicitAny": true,
-    "strictNullChecks": true,
-
-    /* Additional Checks */
-    "noUnusedLocals": true
-  }
+	"files": [
+		"index.d.ts",
+		"index.test-d.ts",
+	],
+	"compilerOptions": {
+		"strict": true,
+		"jsx": "react",
+		"target": "es2018",
+		"lib": [
+			"es2018"
+		],
+		"module": "commonjs",
+		"moduleResolution": "node",
+		"noImplicitAny": true,
+		"strictNullChecks": true,
+		"noUnusedLocals": true
+	}
 }


### PR DESCRIPTION
This PR fixes two things in the types of flags:

1. Without this PR the type of an `isMultiple` flag is still reported to be a non-array.
2. All types are right now reported as always being defined, even when both `isRequired` and `default` is missing. This PR adds `|undefined` in those cases + does so in the case where `isRequired` is a function, as it's kind of hard to figure out what that function will return.

As a separate commit this PR also mirrors the Typescript config from `tsd` + extends it slightly. It does this for two reasons:

1. With a `tsconfig.json` in the project tools like VS Code can automatically configure itself correctly and provide correct feedback. Without the `tsconfig.json` it complained about some of the definition tests.
2. To be able to test `|undefined` one needs to have `strictNullChecks` set, else Typescript will just ignore any `undefined` added in the types.

I also added in `noImplicitAny` and `noUnusedLocals` in the `tsconfig.json` as both of those are helpful and good practice as well.

**Somewhat breaking:**

The addition of `|undefined` to all types that are missing both `isRequired` and `default` can cause some complaints in the code for those who have `strictNullChecks` set to `true`. For everyone else it will cause no change.

These complaints are correct though, but might cause some headaches for eg. those without lock-files, where it can have their CI fail.