### PR TITLE
Make `isMultiple` non-greedy

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -136,7 +136,7 @@ declare namespace meow {
 
 		const cli = meow(`
 			Usage
-			  $ foo
+				$ foo
 
 			Options
 				--rainbow, -r  Include a rainbow

--- a/index.d.ts
+++ b/index.d.ts
@@ -40,6 +40,8 @@ declare namespace meow {
 		- `isRequired`: Determine if the flag is required.
 			If it's only known at runtime whether the flag is required or not you can pass a Function instead of a boolean, which based on the given flags and other non-flag arguments should decide if the flag is required.
 		- `isMultiple`: Indicates a flag can be set multiple times. Values are turned into an array. (Default: false)
+			Multiple values are provided by specifying the flag multiple times, e.g. `$ foo -u rainbow -u cat`.
+			Space- or comma-separated values are *not* supported.
 
 		@example
 		```
@@ -198,24 +200,24 @@ declare namespace meow {
 
 	type TypedFlag<Flag extends AnyFlag> =
 		Flag extends {type: 'number'}
-			? number
-			: Flag extends {type: 'string'}
-				? string
-				: Flag extends {type: 'boolean'}
-					? boolean
-					: unknown;
+		? number
+		: Flag extends {type: 'string'}
+		? string
+		: Flag extends {type: 'boolean'}
+		? boolean
+		: unknown;
 
 	type PossiblyOptionalFlag<Flag extends AnyFlag, FlagType> =
 		Flag extends {isRequired: true}
-			? FlagType
-			: Flag extends {default: any}
-				? FlagType
-				: FlagType | undefined;
+		? FlagType
+		: Flag extends {default: any}
+		? FlagType
+		: FlagType | undefined;
 
 	type TypedFlags<Flags extends AnyFlags> = {
 		[F in keyof Flags]: Flags[F] extends {isMultiple: true}
-			? PossiblyOptionalFlag<Flags[F], Array<TypedFlag<Flags[F]>>>
-			: PossiblyOptionalFlag<Flags[F], TypedFlag<Flags[F]>>
+		? PossiblyOptionalFlag<Flags[F], Array<TypedFlag<Flags[F]>>>
+		: PossiblyOptionalFlag<Flags[F], TypedFlag<Flags[F]>>
 	};
 
 	interface Result<Flags extends AnyFlags> {
@@ -269,14 +271,14 @@ import foo = require('.');
 
 const cli = meow(`
 	Usage
-	  $ foo <input>
+		$ foo <input>
 
 	Options
-	  --rainbow, -r  Include a rainbow
+		--rainbow, -r  Include a rainbow
 
 	Examples
-	  $ foo unicorns --rainbow
-	  🌈 unicorns 🌈
+		$ foo unicorns --rainbow
+		🌈 unicorns 🌈
 `, {
 	flags: {
 		rainbow: {

--- a/index.d.ts
+++ b/index.d.ts
@@ -40,8 +40,7 @@ declare namespace meow {
 		- `isRequired`: Determine if the flag is required.
 			If it's only known at runtime whether the flag is required or not you can pass a Function instead of a boolean, which based on the given flags and other non-flag arguments should decide if the flag is required.
 		- `isMultiple`: Indicates a flag can be set multiple times. Values are turned into an array. (Default: false)
-			Multiple values are provided by specifying the flag multiple times, e.g. `$ foo -u rainbow -u cat`.
-			Space- or comma-separated values are *not* supported.
+			Multiple values are provided by specifying the flag multiple times, e.g. `$ foo -u rainbow -u cat`. Space- or comma-separated values are *not* supported.
 
 		@example
 		```
@@ -137,7 +136,7 @@ declare namespace meow {
 
 		const cli = meow(`
 			Usage
-				$ foo
+			  $ foo
 
 			Options
 				--rainbow, -r  Include a rainbow
@@ -271,14 +270,14 @@ import foo = require('.');
 
 const cli = meow(`
 	Usage
-		$ foo <input>
+	  $ foo <input>
 
 	Options
-		--rainbow, -r  Include a rainbow
+	  --rainbow, -r  Include a rainbow
 
 	Examples
-		$ foo unicorns --rainbow
-		🌈 unicorns 🌈
+	  $ foo unicorns --rainbow
+	  🌈 unicorns 🌈
 `, {
 	flags: {
 		rainbow: {

--- a/index.d.ts
+++ b/index.d.ts
@@ -200,24 +200,24 @@ declare namespace meow {
 
 	type TypedFlag<Flag extends AnyFlag> =
 		Flag extends {type: 'number'}
-		? number
-		: Flag extends {type: 'string'}
-		? string
-		: Flag extends {type: 'boolean'}
-		? boolean
-		: unknown;
+			? number
+			: Flag extends {type: 'string'}
+				? string
+				: Flag extends {type: 'boolean'}
+					? boolean
+					: unknown;
 
 	type PossiblyOptionalFlag<Flag extends AnyFlag, FlagType> =
 		Flag extends {isRequired: true}
-		? FlagType
-		: Flag extends {default: any}
-		? FlagType
-		: FlagType | undefined;
+			? FlagType
+			: Flag extends {default: any}
+				? FlagType
+				: FlagType | undefined;
 
 	type TypedFlags<Flags extends AnyFlags> = {
 		[F in keyof Flags]: Flags[F] extends {isMultiple: true}
-		? PossiblyOptionalFlag<Flags[F], Array<TypedFlag<Flags[F]>>>
-		: PossiblyOptionalFlag<Flags[F], TypedFlag<Flags[F]>>
+			? PossiblyOptionalFlag<Flags[F], Array<TypedFlag<Flags[F]>>>
+			: PossiblyOptionalFlag<Flags[F], TypedFlag<Flags[F]>>
 	};
 
 	interface Result<Flags extends AnyFlags> {

--- a/index.d.ts
+++ b/index.d.ts
@@ -40,7 +40,7 @@ declare namespace meow {
 		- `isRequired`: Determine if the flag is required.
 			If it's only known at runtime whether the flag is required or not you can pass a Function instead of a boolean, which based on the given flags and other non-flag arguments should decide if the flag is required.
 		- `isMultiple`: Indicates a flag can be set multiple times. Values are turned into an array. (Default: false)
-			Multiple values are provided by specifying the flag multiple times, e.g. `$ foo -u rainbow -u cat`. Space- or comma-separated values are *not* supported.
+			Multiple values are provided by specifying the flag multiple times, for example, `$ foo -u rainbow -u cat`. Space- or comma-separated values are *not* supported.
 
 		@example
 		```

--- a/index.js
+++ b/index.js
@@ -124,11 +124,13 @@ const meow = (helpText, options) => {
 
 	parserOptions = buildParserOptions(parserOptions);
 
+	parserOptions.configuration = {
+		...parserOptions.configuration,
+		'greedy-arrays': false
+	};
+
 	if (parserOptions['--']) {
-		parserOptions.configuration = {
-			...parserOptions.configuration,
-			'populate--': true
-		};
+		parserOptions.configuration['populate--'] = true;
 	}
 
 	const {pkg} = options;

--- a/readme.md
+++ b/readme.md
@@ -143,7 +143,7 @@ The key is the flag name and the value is an object with any of:
 	- The second argument is the **input** string array, which contains the non-flag arguments.
 	- The function should return a `boolean`, true if the flag is required, otherwise false.
 - `isMultiple`: Indicates a flag can be set multiple times. Values are turned into an array. (Default: false)
-	- Multiple values are provided by specifying the flag multiple times, e.g. `$ foo -u rainbow -u cat`. Space- or comma-separated values are *not* supported.
+	- Multiple values are provided by specifying the flag multiple times, for example, `$ foo -u rainbow -u cat`. Space- or comma-separated values are [currently *not* supported](https://github.com/sindresorhus/meow/issues/164).
 
 Example:
 

--- a/readme.md
+++ b/readme.md
@@ -143,6 +143,7 @@ The key is the flag name and the value is an object with any of:
 	- The second argument is the **input** string array, which contains the non-flag arguments.
 	- The function should return a `boolean`, true if the flag is required, otherwise false.
 - `isMultiple`: Indicates a flag can be set multiple times. Values are turned into an array. (Default: false)
+	- Multiple values are provided by specifying the flag multiple times, e.g. `$ foo -u rainbow -u cat`. Space- or comma-separated values are *not* supported.
 
 Example:
 

--- a/test/is-required-flag.js
+++ b/test/is-required-flag.js
@@ -87,9 +87,9 @@ test('spawn cli and test isRequired with isMultiple giving a single value', asyn
 	t.is(stdout, '[ 1 ]');
 });
 
-test('spawn cli and test isRequired with isMultiple giving a multiple values', async t => {
-	const {stdout} = await execa(fixtureRequiredMultiplePath, ['--test', '1', '2', '3']);
-	t.is(stdout, '[ 1, 2, 3 ]');
+test('spawn cli and test isRequired with isMultiple giving multiple values', async t => {
+	const {stdout} = await execa(fixtureRequiredMultiplePath, ['--test', '1', '--test', '2']);
+	t.is(stdout, '[ 1, 2 ]');
 });
 
 test('spawn cli and test isRequired with isMultiple giving no values, but flag is given', async t => {

--- a/test/test.js
+++ b/test/test.js
@@ -355,6 +355,20 @@ test('isMultiple - flag with space separated values', t => {
 	t.deepEqual(flags.foo, ['bar']);
 });
 
+test('isMultiple - flag with comma separated values', t => {
+	t.deepEqual(meow({
+		argv: ['--foo', 'bar,baz'],
+		flags: {
+			foo: {
+				type: 'string',
+				isMultiple: true
+			}
+		}
+	}).flags, {
+		foo: ['bar,baz']
+	});
+});
+
 test('single flag set more than once => throws', t => {
 	t.throws(() => {
 		meow({

--- a/test/test.js
+++ b/test/test.js
@@ -341,7 +341,7 @@ test('isMultiple - flag set multiple times', t => {
 });
 
 test('isMultiple - flag with space separated values', t => {
-	t.deepEqual(meow({
+	const {input, flags} = meow({
 		argv: ['--foo', 'bar', 'baz'],
 		flags: {
 			foo: {
@@ -349,9 +349,10 @@ test('isMultiple - flag with space separated values', t => {
 				isMultiple: true
 			}
 		}
-	}).flags, {
-		foo: ['bar', 'baz']
 	});
+
+	t.deepEqual(input, ['baz']);
+	t.deepEqual(flags.foo, ['bar']);
 });
 
 test('single flag set more than once => throws', t => {


### PR DESCRIPTION
I.e don't consume more than one argument.

The default behavior of `yargs-parser` is to [greedily consume array flag arguments](https://github.com/yargs/yargs-parser#greedy-arrays).

I also realized it doesn't support comma-separated values. Not sure if we want that or not, but I'll make a separate PR and let you be the judge.

Fixes #160 