### PR TITLE
Default `isMultiple` to empty array

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -131,7 +131,7 @@ declare namespace meow {
 
 		_Note: If used in conjunction with `isMultiple`, the default flag value is set to `[]`._
 
-		__Caution: Explicitly specifying undefined for `booleanDefault` has different meaning from omitting key itself.__
+		__Caution: Explicitly specifying `undefined` for `booleanDefault` has different meaning from omitting key itself.__
 
 		@example
 		```

--- a/index.d.ts
+++ b/index.d.ts
@@ -202,24 +202,24 @@ declare namespace meow {
 
 	type TypedFlag<Flag extends AnyFlag> =
 		Flag extends {type: 'number'}
-		? number
-		: Flag extends {type: 'string'}
-		? string
-		: Flag extends {type: 'boolean'}
-		? boolean
-		: unknown;
+			? number
+			: Flag extends {type: 'string'}
+				? string
+				: Flag extends {type: 'boolean'}
+					? boolean
+					: unknown;
 
 	type PossiblyOptionalFlag<Flag extends AnyFlag, FlagType> =
 		Flag extends {isRequired: true}
-		? FlagType
-		: Flag extends {default: any}
-		? FlagType
-		: FlagType | undefined;
+			? FlagType
+			: Flag extends {default: any}
+				? FlagType
+				: FlagType | undefined;
 
 	type TypedFlags<Flags extends AnyFlags> = {
 		[F in keyof Flags]: Flags[F] extends {isMultiple: true}
-		? PossiblyOptionalFlag<Flags[F], Array<TypedFlag<Flags[F]>>>
-		: PossiblyOptionalFlag<Flags[F], TypedFlag<Flags[F]>>
+			? PossiblyOptionalFlag<Flags[F], Array<TypedFlag<Flags[F]>>>
+			: PossiblyOptionalFlag<Flags[F], TypedFlag<Flags[F]>>
 	};
 
 	interface Result<Flags extends AnyFlags> {
@@ -273,14 +273,14 @@ import foo = require('.');
 
 const cli = meow(`
 	Usage
-		$ foo <input>
+	  $ foo <input>
 
 	Options
-		--rainbow, -r  Include a rainbow
+	  --rainbow, -r  Include a rainbow
 
 	Examples
-		$ foo unicorns --rainbow
-		🌈 unicorns 🌈
+	  $ foo unicorns --rainbow
+	  🌈 unicorns 🌈
 `, {
 	flags: {
 		rainbow: {

--- a/index.d.ts
+++ b/index.d.ts
@@ -127,7 +127,7 @@ declare namespace meow {
 		/**
 		Value of `boolean` flags not defined in `argv`.
 
-		If set to `undefined` the flags not defined in `argv` will be excluded from the result. The `default` value set in `boolean` flags take precedence over `booleanDefault`.
+		If set to `undefined`, the flags not defined in `argv` will be excluded from the result. The `default` value set in `boolean` flags take precedence over `booleanDefault`.
 
 		_Note: If used in conjunction with `isMultiple`, the default flag value is set to `[]`._
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -125,7 +125,11 @@ declare namespace meow {
 		readonly inferType?: boolean;
 
 		/**
-		Value of `boolean` flags not defined in `argv`. If set to `undefined` the flags not defined in `argv` will be excluded from the result. The `default` value set in `boolean` flags take precedence over `booleanDefault`.
+		Value of `boolean` flags not defined in `argv`.
+
+		If set to `undefined` the flags not defined in `argv` will be excluded from the result. The `default` value set in `boolean` flags take precedence over `booleanDefault`.
+
+		_Note: If used in conjunction with `isMultiple`, the default flag value is set to `[]`._
 
 		__Caution: Explicitly specifying undefined for `booleanDefault` has different meaning from omitting key itself.__
 
@@ -198,24 +202,24 @@ declare namespace meow {
 
 	type TypedFlag<Flag extends AnyFlag> =
 		Flag extends {type: 'number'}
-			? number
-			: Flag extends {type: 'string'}
-				? string
-				: Flag extends {type: 'boolean'}
-					? boolean
-					: unknown;
+		? number
+		: Flag extends {type: 'string'}
+		? string
+		: Flag extends {type: 'boolean'}
+		? boolean
+		: unknown;
 
 	type PossiblyOptionalFlag<Flag extends AnyFlag, FlagType> =
 		Flag extends {isRequired: true}
-			? FlagType
-			: Flag extends {default: any}
-				? FlagType
-				: FlagType | undefined;
+		? FlagType
+		: Flag extends {default: any}
+		? FlagType
+		: FlagType | undefined;
 
 	type TypedFlags<Flags extends AnyFlags> = {
 		[F in keyof Flags]: Flags[F] extends {isMultiple: true}
-			? PossiblyOptionalFlag<Flags[F], Array<TypedFlag<Flags[F]>>>
-			: PossiblyOptionalFlag<Flags[F], TypedFlag<Flags[F]>>
+		? PossiblyOptionalFlag<Flags[F], Array<TypedFlag<Flags[F]>>>
+		: PossiblyOptionalFlag<Flags[F], TypedFlag<Flags[F]>>
 	};
 
 	interface Result<Flags extends AnyFlags> {
@@ -269,14 +273,14 @@ import foo = require('.');
 
 const cli = meow(`
 	Usage
-	  $ foo <input>
+		$ foo <input>
 
 	Options
-	  --rainbow, -r  Include a rainbow
+		--rainbow, -r  Include a rainbow
 
 	Examples
-	  $ foo unicorns --rainbow
-	  🌈 unicorns 🌈
+		$ foo unicorns --rainbow
+		🌈 unicorns 🌈
 `, {
 	flags: {
 		rainbow: {

--- a/index.js
+++ b/index.js
@@ -68,6 +68,7 @@ const buildParserFlags = ({flags, booleanDefault}) =>
 
 		if (flag.isMultiple) {
 			flag.type = flag.type ? `${flag.type}-array` : 'array';
+			flag.default = flag.default || [];
 			delete flag.isMultiple;
 		}
 

--- a/readme.md
+++ b/readme.md
@@ -245,6 +245,8 @@ The `default` value set in `boolean` flags take precedence over `booleanDefault`
 
 _Note: If used in conjunction with `isMultiple`, the default flag value is set to `[]`._
 
+__Caution: Explicitly specifying `undefined` for `booleanDefault` has different meaning from omitting key itself.__
+
 Example:
 
 ```js

--- a/readme.md
+++ b/readme.md
@@ -239,8 +239,11 @@ Type: `boolean | null | undefined`\
 Default: `false`
 
 Value of `boolean` flags not defined in `argv`.
+
 If set to `undefined` the flags not defined in `argv` will be excluded from the result.
 The `default` value set in `boolean` flags take precedence over `booleanDefault`.
+
+_Note: If used in conjunction with `isMultiple`, the default flag value is set to `[]`._
 
 Example:
 

--- a/readme.md
+++ b/readme.md
@@ -240,7 +240,7 @@ Default: `false`
 
 Value of `boolean` flags not defined in `argv`.
 
-If set to `undefined` the flags not defined in `argv` will be excluded from the result.
+If set to `undefined`, the flags not defined in `argv` will be excluded from the result.
 The `default` value set in `boolean` flags take precedence over `booleanDefault`.
 
 _Note: If used in conjunction with `isMultiple`, the default flag value is set to `[]`._

--- a/test/test.js
+++ b/test/test.js
@@ -312,6 +312,20 @@ test('supports `number` flag type - throws on incorrect default value', t => {
 	});
 });
 
+test('isMultiple - unset flag returns empty array', t => {
+	t.deepEqual(meow({
+		argv: [],
+		flags: {
+			foo: {
+				type: 'string',
+				isMultiple: true
+			}
+		}
+	}).flags, {
+		foo: []
+	});
+});
+
 test('isMultiple - flag set once returns array', t => {
 	t.deepEqual(meow({
 		argv: ['--foo=bar'],
@@ -408,25 +422,6 @@ test('isMultiple - boolean flag is false by default', t => {
 	});
 });
 
-test('isMultiple - flag with `booleanDefault: undefined` => filter out unset boolean args', t => {
-	t.deepEqual(meow({
-		argv: ['--foo'],
-		booleanDefault: undefined,
-		flags: {
-			foo: {
-				type: 'boolean',
-				isMultiple: true
-			},
-			bar: {
-				type: 'boolean',
-				isMultiple: true
-			}
-		}
-	}).flags, {
-		foo: [true]
-	});
-});
-
 test('isMultiple - number flag', t => {
 	t.deepEqual(meow({
 		argv: ['--foo=1.3', '--foo=-1'],
@@ -508,17 +503,6 @@ test('isMultiple - handles multi-word flag name', t => {
 	}).flags, {
 		fooBar: ['baz']
 	});
-});
-
-test('isMultiple - handles non-set flags correctly', t => {
-	t.deepEqual(meow({
-		argv: [],
-		flags: {
-			foo: {
-				isMultiple: true
-			}
-		}
-	}).flags, {});
 });
 
 if (NODE_MAJOR_VERSION >= 14) {


### PR DESCRIPTION
Note: Changes behavior for `booleanDefault: undefined` as well. With this change in place, I don't think it makes sense to filter out unset boolean array flags any longer.

Fixes #161 