### PR TITLE
Gracefully handle package.json not being found

### DIFF
--- a/index.js
+++ b/index.js
@@ -91,11 +91,14 @@ const meow = (helpText, options) => {
 		helpText = '';
 	}
 
+	const foundPkg = readPkgUp.sync({
+		cwd: parentDir,
+		normalize: false
+	})
+	const pkg = foundPkg ? foundPkg.packageJson : {}
+
 	options = {
-		pkg: readPkgUp.sync({
-			cwd: parentDir,
-			normalize: false
-		})?.packageJson || {},
+		pkg,
 		argv: process.argv.slice(2),
 		flags: {},
 		inferType: false,

--- a/index.js
+++ b/index.js
@@ -95,7 +95,7 @@ const meow = (helpText, options) => {
 		pkg: readPkgUp.sync({
 			cwd: parentDir,
 			normalize: false
-		}).packageJson || {},
+		})?.packageJson || {},
 		argv: process.argv.slice(2),
 		flags: {},
 		inferType: false,

--- a/index.js
+++ b/index.js
@@ -95,10 +95,8 @@ const meow = (helpText, options) => {
 		cwd: parentDir,
 		normalize: false
 	})
-	const pkg = foundPkg ? foundPkg.packageJson : {}
-
 	options = {
-		pkg,
+		pkg: foundPkg ? foundPkg.packageJson : {},
 		argv: process.argv.slice(2),
 		flags: {},
 		inferType: false,

--- a/index.js
+++ b/index.js
@@ -95,6 +95,7 @@ const meow = (helpText, options) => {
 		cwd: parentDir,
 		normalize: false
 	});
+
 	options = {
 		pkg: foundPkg ? foundPkg.packageJson : {},
 		argv: process.argv.slice(2),

--- a/index.js
+++ b/index.js
@@ -94,7 +94,7 @@ const meow = (helpText, options) => {
 	const foundPkg = readPkgUp.sync({
 		cwd: parentDir,
 		normalize: false
-	})
+	});
 	options = {
 		pkg: foundPkg ? foundPkg.packageJson : {},
 		argv: process.argv.slice(2),


### PR DESCRIPTION
`read-pkg-up`'s `sync()` [can return undefined](https://github.com/sindresorhus/read-pkg-up/blob/4406073/index.d.ts#L82-L84).
If that happens, we try to index into `.packageJson`, which fails.

Making the index operation null-safe makes execution continue on with `pkg` being set to an empty object, which is what seems to be the original intent.