### PR TITLE
Add `allowUnknownFlags` options

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -199,6 +199,13 @@ declare namespace meow {
 		@default true
 		*/
 		readonly hardRejection?: boolean;
+
+		/**
+		Whether to allow unknown flags or not.
+
+		@default true
+		*/
+		readonly allowUnknownFlags?: boolean;
 	}
 
 	type TypedFlag<Flag extends AnyFlag> =

--- a/index.js
+++ b/index.js
@@ -55,8 +55,10 @@ const reportMissingRequiredFlags = missingRequiredFlags => {
 };
 
 const reportUnknownFlags = unknownFlags => {
-	console.error(`Unknown flag${unknownFlags.length > 1 ? 's' : ''}`);
-	console.error(unknownFlags.join('\n'));
+	console.error([
+		`Unknown flag${unknownFlags.length > 1 ? 's' : ''}`,
+		...unknownFlags
+	].join('\n'));
 };
 
 const buildParserFlags = ({flags, booleanDefault}) => {

--- a/index.js
+++ b/index.js
@@ -54,6 +54,11 @@ const reportMissingRequiredFlags = missingRequiredFlags => {
 	}
 };
 
+const reportUnknownFlags = unknownFlags => {
+	console.error(`Unknown flag${unknownFlags.length > 1 ? 's' : ''}`);
+	console.error(unknownFlags.join('\n'));
+};
+
 const buildParserFlags = ({flags, booleanDefault}) => {
 	const parserFlags = {};
 
@@ -110,6 +115,7 @@ const meow = (helpText, options) => {
 		autoVersion: true,
 		booleanDefault: false,
 		hardRejection: true,
+		allowUnknownFlags: true,
 		...options
 	};
 
@@ -137,6 +143,11 @@ const meow = (helpText, options) => {
 
 	if (parserOptions['--']) {
 		parserOptions.configuration['populate--'] = true;
+	}
+
+	if (!options.allowUnknownFlags) {
+		// Collect unknown options in `argv._` to be checked later.
+		parserOptions.configuration['unknown-options-as-args'] = true;
 	}
 
 	const {pkg} = options;
@@ -176,6 +187,14 @@ const meow = (helpText, options) => {
 
 	const input = argv._;
 	delete argv._;
+
+	if (!options.allowUnknownFlags) {
+		const unknownFlags = input.filter(item => typeof item === 'string' && item.startsWith('-'));
+		if (unknownFlags.length > 0) {
+			reportUnknownFlags(unknownFlags);
+			process.exit(2);
+		}
+	}
 
 	const flags = camelCaseKeys(argv, {exclude: ['--', /^\w$/]});
 	const unnormalizedFlags = {...flags};

--- a/readme.md
+++ b/readme.md
@@ -314,6 +314,13 @@ Default: `true`
 
 Whether to use [`hard-rejection`](https://github.com/sindresorhus/hard-rejection) or not. Disabling this can be useful if you need to handle `process.on('unhandledRejection')` yourself.
 
+#### allowUnknownFlags
+
+Type `boolean`\
+Default: `true`
+
+Whether to allow unknown flags or not.
+
 ## Promises
 
 Meow will make unhandled rejected promises [fail hard](https://github.com/sindresorhus/hard-rejection) instead of the default silent fail. Meaning you don't have to manually `.catch()` promises used in your CLI.

--- a/test/allow-unkonwn-flags.js
+++ b/test/allow-unkonwn-flags.js
@@ -6,11 +6,13 @@ const fixtureAllowUnknownFlags = path.join(__dirname, 'fixtures', 'fixture-allow
 
 test('spawn CLI and test specifying unknown flags', async t => {
 	const error = await t.throwsAsync(
-		execa(fixtureAllowUnknownFlags, ['--foo', 'bar', '--unspecified-a', '--unspecified-b', 'input-is-allowed'])
+		execa(fixtureAllowUnknownFlags, ['--foo', 'bar', '--unspecified-a', '--unspecified-b', 'input-is-allowed']),
+		{
+			message: /^Command failed with exit code 2/
+		}
 	);
-	const {stderr, message} = error;
-	t.regex(message, /Command failed with exit code 2/);
-	t.regex(stderr, /Unknown flag/);
+	const {stderr} = error;
+	t.regex(stderr, /Unknown flags/);
 	t.regex(stderr, /--unspecified-a/);
 	t.regex(stderr, /--unspecified-b/);
 	t.notRegex(stderr, /input-is-allowed/);

--- a/test/allow-unkonwn-flags.js
+++ b/test/allow-unkonwn-flags.js
@@ -1,0 +1,22 @@
+import path from 'path';
+import test from 'ava';
+import execa from 'execa';
+
+const fixtureAllowUnknownFlags = path.join(__dirname, 'fixtures', 'fixture-allow-unknown-flags.js');
+
+test('spawn CLI and test specifying unknown flags', async t => {
+	const error = await t.throwsAsync(
+		execa(fixtureAllowUnknownFlags, ['--foo', 'bar', '--unspecified-a', '--unspecified-b', 'input-is-allowed'])
+	);
+	const {stderr, message} = error;
+	t.regex(message, /Command failed with exit code 2/);
+	t.regex(stderr, /Unknown flag/);
+	t.regex(stderr, /--unspecified-a/);
+	t.regex(stderr, /--unspecified-b/);
+	t.notRegex(stderr, /input-is-allowed/);
+});
+
+test('spawn CLI and test specifying known flags', async t => {
+	const {stdout} = await execa(fixtureAllowUnknownFlags, ['--foo', 'bar']);
+	t.is(stdout, 'bar');
+});

--- a/test/fixtures/fixture-allow-unknown-flags.js
+++ b/test/fixtures/fixture-allow-unknown-flags.js
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+'use strict';
+const meow = require('../..');
+
+const cli = meow({
+	description: 'Custom description',
+	help: `
+		Usage
+		  foo <input>
+  `,
+	allowUnknownFlags: false,
+	flags: {
+		foo: {
+			type: 'string'
+		}
+	}
+});
+
+console.log(cli.flags.foo);


### PR DESCRIPTION
fix #126 

To simplify figuring out which flags are unknown, I tried:

1. Pass [unknown-options-as-args](https://www.npmjs.com/package/yargs-parser#unknown-options-as-args) to yargs-parser first;
2. Filter unknown options collected in `argv._` which starts with `-`.

And I also make `allowUnknownFlags` be `true` by default to keep compatibility.

Let me know if I missed something.