### PR TITLE
Allow `default` property of `Flag` types to accept arrays

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -12,17 +12,17 @@ Callback function to determine if a flag is required during runtime.
 */
 export type IsRequiredPredicate = (flags: Readonly<AnyFlags>, input: readonly string[]) => boolean;
 
-export interface Flag<Type extends FlagType, Default> {
+export interface Flag<Type extends FlagType, Default, IsMultiple = false> {
 	readonly type?: Type;
 	readonly alias?: string;
 	readonly default?: Default;
 	readonly isRequired?: boolean | IsRequiredPredicate;
-	readonly isMultiple?: boolean;
+	readonly isMultiple?: IsMultiple;
 }
 
-type StringFlag = Flag<'string', string>;
-type BooleanFlag = Flag<'boolean', boolean>;
-type NumberFlag = Flag<'number', number>;
+type StringFlag = Flag<'string', string> | Flag<'string', string[], true>;
+type BooleanFlag = Flag<'boolean', boolean> | Flag<'boolean', boolean[], true>;
+type NumberFlag = Flag<'number', number> | Flag<'number', number[], true>;
 type AnyFlag = StringFlag | BooleanFlag | NumberFlag;
 type AnyFlags = Record<string, AnyFlag>;
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -89,8 +89,8 @@ const options = {
 
 meow('', options);
 
-expectAssignable<AnyFlag>({type: 'string',	default: 'cat'});
-expectAssignable<AnyFlag>({type: 'number',	default: 42});
+expectAssignable<AnyFlag>({type: 'string', default: 'cat'});
+expectAssignable<AnyFlag>({type: 'number', default: 42});
 expectAssignable<AnyFlag>({type: 'boolean', default: true});
 
 expectAssignable<AnyFlag>({type: 'string', default: undefined});
@@ -98,7 +98,7 @@ expectAssignable<AnyFlag>({type: 'number', default: undefined});
 expectAssignable<AnyFlag>({type: 'boolean', default: undefined});
 
 expectAssignable<AnyFlag>({type: 'string', isMultiple: true, default: ['cat']});
-expectAssignable<AnyFlag>({type: 'number', isMultiple: true,	default: [42]});
+expectAssignable<AnyFlag>({type: 'number', isMultiple: true, default: [42]});
 expectAssignable<AnyFlag>({type: 'boolean', isMultiple: true, default: [false]});
 
 expectError<AnyFlag>({type: 'string', isMultiple: true, default: 'cat'});

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,6 +1,6 @@
-import {expectAssignable, expectType} from 'tsd';
+import {expectAssignable, expectError, expectType} from 'tsd';
 import {PackageJson} from 'type-fest';
-import meow, {Result} from './index.js';
+import meow, {Result, AnyFlag} from './index.js';
 
 const importMeta = import.meta;
 
@@ -23,6 +23,15 @@ expectAssignable<{flags: {foo: string | undefined}}>(
 );
 expectAssignable<{flags: {foo: boolean | undefined}}>(
 	meow({importMeta, flags: {foo: {type: 'boolean'}}})
+);
+expectAssignable<{flags: {foo: number[] | undefined}}>(
+	meow({importMeta, flags: {foo: {type: 'number', isMultiple: true}}})
+);
+expectAssignable<{flags: {foo: string[] | undefined}}>(
+	meow({importMeta, flags: {foo: {type: 'string', isMultiple: true}}})
+);
+expectAssignable<{flags: {foo: boolean[] | undefined}}>(
+	meow({importMeta, flags: {foo: {type: 'boolean', isMultiple: true}}})
 );
 expectType<Result<never>>(meow({importMeta, description: 'foo'}));
 expectType<Result<never>>(meow({importMeta, description: false}));
@@ -79,3 +88,19 @@ const options = {
 } as const;
 
 meow('', options);
+
+expectAssignable<AnyFlag>({type: 'string',	default: 'cat'});
+expectAssignable<AnyFlag>({type: 'number',	default: 42});
+expectAssignable<AnyFlag>({type: 'boolean', default: true});
+
+expectAssignable<AnyFlag>({type: 'string', default: undefined});
+expectAssignable<AnyFlag>({type: 'number', default: undefined});
+expectAssignable<AnyFlag>({type: 'boolean', default: undefined});
+
+expectAssignable<AnyFlag>({type: 'string', isMultiple: true, default: ['cat']});
+expectAssignable<AnyFlag>({type: 'number', isMultiple: true,	default: [42]});
+expectAssignable<AnyFlag>({type: 'boolean', isMultiple: true, default: [false]});
+
+expectError<AnyFlag>({type: 'string', isMultiple: true, default: 'cat'});
+expectError<AnyFlag>({type: 'number', isMultiple: true, default: 42});
+expectError<AnyFlag>({type: 'boolean', isMultiple: true, default: false});


### PR DESCRIPTION
Fixes: https://github.com/sindresorhus/meow/issues/189