### PR TITLE
feat: introduce `preferNestedFlags` option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -213,6 +213,13 @@ export interface Options<Flags extends AnyFlags> {
 	@default true
 	*/
 	readonly allowUnknownFlags?: boolean;
+
+	/**
+	Prefer nested flags to be parsed first.
+
+	@default false
+	 */
+	readonly preferNestedFlags?: boolean;
 }
 
 type TypedFlag<Flag extends AnyFlag> =

--- a/index.js
+++ b/index.js
@@ -116,9 +116,11 @@ const meow = (helpText, options = {}) => {
 		normalize: false,
 	});
 
+	const argvStart = options.preferNestedFlags && process.argv.includes('--') ? process.argv.indexOf('--') + 1 : 2;
+
 	options = {
 		pkg: foundPackage ? foundPackage.packageJson : {},
-		argv: process.argv.slice(2),
+		argv: process.argv.slice(argvStart),
 		flags: {},
 		inferType: false,
 		input: 'string',
@@ -128,6 +130,7 @@ const meow = (helpText, options = {}) => {
 		booleanDefault: false,
 		hardRejection: true,
 		allowUnknownFlags: true,
+		preferNestedFlags: false,
 		...options,
 	};
 

--- a/package.json
+++ b/package.json
@@ -43,17 +43,17 @@
 	],
 	"dependencies": {
 		"@types/minimist": "^1.2.2",
-		"camelcase-keys": "^7.0.0",
-		"decamelize": "^5.0.0",
+		"camelcase-keys": "^7.0.2",
+		"decamelize": "^6.0.0",
 		"decamelize-keys": "^1.1.0",
 		"hard-rejection": "^2.1.0",
 		"minimist-options": "4.1.0",
-		"normalize-package-data": "^3.0.2",
-		"read-pkg-up": "^8.0.0",
+		"normalize-package-data": "^4.0.0",
+		"read-pkg-up": "^9.1.0",
 		"redent": "^4.0.0",
 		"trim-newlines": "^4.0.2",
-		"type-fest": "^1.2.2",
-		"yargs-parser": "^20.2.9"
+		"type-fest": "^2.12.2",
+		"yargs-parser": "^21.0.1"
 	},
 	"devDependencies": {
 		"ava": "^3.15.0",

--- a/readme.md
+++ b/readme.md
@@ -292,6 +292,13 @@ Default: `true`
 
 Whether to allow unknown flags or not.
 
+##### preferNestedFlags
+
+Type `boolean`\
+Default: `false`
+
+This option makes sense if your CLI may be invoked inside another one. For example, `npx -p foo -p bar bar-cli -- --opts-for='bar-cli'`.
+
 ## Promises
 
 Meow will make unhandled rejected promises [fail hard](https://github.com/sindresorhus/hard-rejection) instead of the default silent fail. Meaning you don't have to manually `.catch()` promises used in your CLI.

--- a/test/fixtures/fixture-prefer-nested-flags.js
+++ b/test/fixtures/fixture-prefer-nested-flags.js
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+import meow from '../../index.js';
+
+const cli = meow({
+	importMeta: import.meta,
+	description: 'Custom description',
+	help: `
+		Usage
+		  foo <input>
+  `,
+	preferNestedFlags: true,
+	flags: {
+		foo: {
+			type: 'string',
+		},
+	},
+});
+
+console.log(cli.flags.foo);

--- a/test/prefer-nested-flags.js
+++ b/test/prefer-nested-flags.js
@@ -1,0 +1,17 @@
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+import test from 'ava';
+import {execa} from 'execa';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const fixturePreferNestedFlags = path.join(__dirname, 'fixtures', 'fixture-prefer-nested-flags.js');
+
+test('spawn CLI and check nested flags capture', async t => {
+	const {stdout} = await execa(fixturePreferNestedFlags, ['--foo', 'bar', '--', '--foo', 'baz']);
+	t.is(stdout, 'baz');
+});
+
+test('spawn CLI and test getting known flags if no nesting found', async t => {
+	const {stdout} = await execa(fixturePreferNestedFlags, ['--foo', 'bar']);
+	t.is(stdout, 'bar');
+});


### PR DESCRIPTION
[Real-world issue](https://github.com/qiwi-forks/docma/runs/6279032275?check_suite_focus=true#step:4:40): I got stuck in a corner case when I couldn't parametrize CLI inside another CLI:

```shell
npx -p foo -p bar bar-cli -- --opts-for='bar-cli'

Too many non-option arguments: got 2, maximum of 0
Error: Process completed with exit code 1.
```

I suggest introducing `preferNestedFlags` option to workaround the limitation:
```js
const argvStart = options.preferNestedFlags && process.argv.includes('--') ? process.argv.indexOf('--') + 1 : 2;

options = {
    pkg: foundPackage ? foundPackage.packageJson : {},
    argv: process.argv.slice(argvStart),
    ...
};
```
