### PR TITLE
Add subcommands support

### DIFF
--- a/barista.js
+++ b/barista.js
@@ -1,0 +1,77 @@
+// @ts-nocheck
+
+/**
+Example subcommands API:
+
+node barista.js
+node barista.js brew
+node barista.js brew tea
+node barista.js brew coffee --temp cold
+
+// Toggle the `allowParentFlags` option:
+node barista.js brew coffee --parentFlag
+
+// Set `allowParentFlags` and `allowUnknownFlags` to `true`:
+node barista.js --help
+node barista.js brew --help
+node barista.js brew coffee --help
+*/
+
+import meow from "./index.js";
+import redent from 'redent';
+
+const cli = meow({
+	importMeta: import.meta,
+  allowParentFlags: true,
+	allowUnknownFlags: false,
+	description: "Your friendly neighborhood barista",
+	help: redent(`
+	  Usage:
+	    barista brew <beverage> <options>`, 2),
+	flags: {
+		parentFlag: { type: "boolean" },
+	},
+	commands: {
+		brew: {
+			description: "A prompt to select what to brew",
+			help: redent(`
+			  Usage:
+				  barista brew <beverage> <options>`, 2),
+			flags: {
+				temp: { type: "string", default: "hot" },
+			},
+			handler: () => console.log("What do you want to brew?"),
+			commands: {
+				coffee: {
+					description: "Brew coffee",
+					help: redent(`
+					  Usage:
+						  barista brew coffee <options>`, 2),
+					handler: (cli) => console.log(`Here's your ${cli.flags.temp} coffee!`),
+				},
+				tea: {
+					description: "Brew tea",
+					help: redent(`
+						Usage:
+						  barista brew tea <options>`, 2),
+					handler: (cli) => console.log(`Here's your ${cli.flags.temp} tea!`),
+				},
+			},
+		},
+	},
+});
+
+cli.command.options.handler?.(cli)
+
+/**
+Example output:
+
+cli.command === {
+	args: ['brew', 'coffee'],
+	options: {
+		description: "Brew coffee",
+		help: `...`
+		handler: (cli) => console.log(`Here's your ${cli.flags.temp} coffee!`),
+	}
+}
+*/


### PR DESCRIPTION
I've been experimenting with an alternative approach to [PR# 205](https://github.com/sindresorhus/meow/pull/205) for adding `subcommands` support. My favorite feature of `meow` is the objects as configuration convention for `flags` and I was interested in exploring how to carry over that pattern for `subcommands`. I'm pretty satisfied with the POC and would love some initial feedback before I continue iterating and moving this PR out of draft.

Key features:
- Objects as configuration for `subcommands`
- Out of the box support for nested `subcommands`
- `subcommands` use the existing `meow.options` properties to keep the API minimal, extensible, and familiar
- Using `--help` (with `autoHelp: true`)  automatically shows the help text for the current `subcommand`
- A new `allowParentFlags` option is introduced to restrict top level `options.flags` from being used with a given `subcommand`
> Note: Since the `subcommand.options` recursively merge, authors have the ability to override `meow.options` uniquely for each `subcommand`
- And finally, a simple return value (e.g. `cli.command`) containing the input `args` of the `subcommand` and a reference to the resolved `subcommand`s options

Here is a subset of the proposed API! Though, I recommend pulling down the branch and testing out `barista.js` with the provided examples.

```js
const cli = meow({
  description: "Your friendly neighborhood barista",
  help: `
    Usage:
      barista brew <beverage> <options>`,
  commands: {
    brew: {
      description: "A prompt to select what to brew",
      help: `
        Usage:
          barista brew <beverage> <options>`,
      flags: {
        temp: { type: "string", default: "hot" },
      },
      handler: () => console.log("What do you want to brew?"),
      commands: {
        coffee: {
          description: "Brew coffee",
          help: `
            Usage:
              barista brew coffee <options>`,
          handler: (cli) => console.log(`Here's your ${cli.flags.temp} coffee!`),
        },
        tea: {
          description: "Brew tea",
          help: `
            Usage:
              barista brew tea <options>`,
          handler: (cli) => console.log(`Here's your ${cli.flags.temp} tea!`),
        },
      },
    },
  },
});

cli.command.options.handler?.(cli)
```
  
<img width="817" alt="image" src="https://user-images.githubusercontent.com/32409546/171987587-dd1050aa-3f8b-472d-b08c-4aadab5d92d2.png">