### PR TITLE
Set showHelp return type to never

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -268,7 +268,7 @@ export interface Result<Flags extends AnyFlags> {
 
 	@param exitCode - The exit code to use. Default: `2`.
 	*/
-	showHelp: (exitCode?: number) => void;
+	showHelp: (exitCode?: number) => never;
 
 	/**
 	Show the version text and exit.


### PR DESCRIPTION
Since `showHelp()` calls into `process.exit()`, they should use the same return type.

The return type of `process.exit()` is `never`, not `void`. This tells the typescript compiler that code branches that have `showHelp()` terminate, and that any code written as executing after `showHelp()` should be considered dead code (similar to code after a `return` statement).