### PR TITLE
Fix for custom config for help

### DIFF
--- a/index.js
+++ b/index.js
@@ -149,11 +149,11 @@ const meow = (helpText, options = {}) => {
 
 	// Add --help and --version to known flags if autoHelp or autoVersion are set
 	if (!options.allowUnknownFlags) {
-		if (options.autoHelp) {
+		if (options.autoHelp && !parserOptions.help) {
 			parserOptions.help = {type: 'boolean'};
 		}
 
-		if (options.autoVersion) {
+		if (options.autoVersion && !parserOptions.version) {
 			parserOptions.version = {type: 'boolean'};
 		}
 	}

--- a/test/allow-unknown-flags.js
+++ b/test/allow-unknown-flags.js
@@ -7,6 +7,7 @@ import {readPackage} from 'read-pkg';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const fixtureAllowUnknownFlags = path.join(__dirname, 'fixtures', 'fixture-allow-unknown-flags.js');
+const fixtureAllowUnknownFlagsWithHelp = path.join(__dirname, 'fixtures', 'fixture-allow-unknown-flags-with-help.js');
 
 test('spawn CLI and test specifying unknown flags', async t => {
 	const error = await t.throwsAsync(
@@ -60,4 +61,15 @@ test('spawn CLI and test version as an unknown flag', async t => {
 	const {stderr} = error;
 	t.regex(stderr, /Unknown flag/);
 	t.regex(stderr, /--version/);
+});
+
+test('spawn CLI and test help with custom config', async t => {
+	const {stdout} = await execa(fixtureAllowUnknownFlagsWithHelp, ['-h']);
+	t.is(stdout, indentString('\nCustom description\n\nUsage\n  foo <input>\n\n', 2));
+});
+
+test('spawn CLI and test version with custom config', async t => {
+	const pkg = await readPackage();
+	const {stdout} = await execa(fixtureAllowUnknownFlagsWithHelp, ['-v']);
+	t.is(stdout, pkg.version);
 });

--- a/test/fixtures/fixture-allow-unknown-flags-with-help.js
+++ b/test/fixtures/fixture-allow-unknown-flags-with-help.js
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+import meow from '../../index.js';
+
+const cli = meow({
+	importMeta: import.meta,
+	description: 'Custom description',
+	help: `
+		Usage
+		  foo <input>
+  `,
+	allowUnknownFlags: false,
+	flags: {
+		help: {
+			alias: 'h',
+			type: 'boolean',
+		},
+		version: {
+			alias: 'v',
+			type: 'boolean',
+		},
+	},
+});
+
+console.log(cli.flags.help);


### PR DESCRIPTION
Fixes #216

Fixes a bug when an existing custom config for `help` or `version` was overridden when `allowUnknownFlags: false`.