### PR TITLE
Rename `alias` to `shortFlag`

### DIFF
--- a/estest/index.js
+++ b/estest/index.js
@@ -17,7 +17,7 @@ meow(
 		flags: {
 			rainbow: {
 				type: 'boolean',
-				alias: 'r',
+				shortFlag: 'r',
 			},
 		},
 	},

--- a/index.d.ts
+++ b/index.d.ts
@@ -17,7 +17,7 @@ export type IsRequiredPredicate = (flags: Readonly<AnyFlags>, input: readonly st
 
 export type Flag<Type extends FlagType, Default, IsMultiple = false> = {
 	readonly type?: Type;
-	readonly alias?: string;
+	readonly shortFlag?: string;
 	readonly default?: Default;
 	readonly isRequired?: boolean | IsRequiredPredicate;
 	readonly isMultiple?: IsMultiple;
@@ -41,7 +41,7 @@ export type Options<Flags extends AnyFlags> = {
 	The key is the flag name in camel-case and the value is an object with any of:
 
 	- `type`: Type of value. (Possible values: `string` `boolean` `number`)
-	- `alias`: Usually used to define a short flag alias.
+	- `shortFlag`: A short flag alias.
 	- `default`: Default value when the flag is not specified.
 	- `isRequired`: Determine if the flag is required.
 		If it's only known at runtime whether the flag is required or not you can pass a Function instead of a boolean, which based on the given flags and other non-flag arguments should decide if the flag is required.
@@ -55,7 +55,7 @@ export type Options<Flags extends AnyFlags> = {
 	flags: {
 		unicorn: {
 			type: 'string',
-			alias: 'u',
+			shortFlag: 'u',
 			default: ['rainbow', 'cat'],
 			isMultiple: true,
 			isRequired: (flags, input) => {
@@ -165,16 +165,16 @@ export type Options<Flags extends AnyFlags> = {
 			rainbow: {
 				type: 'boolean',
 				default: true,
-				alias: 'r'
+				shortFlag: 'r'
 			},
 				unicorn: {
 				type: 'boolean',
 				default: false,
-				alias: 'u'
+				shortFlag: 'u'
 			},
 			cake: {
 				type: 'boolean',
-				alias: 'c'
+				shortFlag: 'c'
 			},
 			sparkles: {
 				type: 'boolean',
@@ -302,7 +302,7 @@ const cli = meow(`
 	flags: {
 		rainbow: {
 			type: 'boolean',
-			alias: 'r'
+			shortFlag: 'r'
 		}
 	}
 });

--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ const getMissingRequiredFlags = (flags, receivedFlags, input) => {
 const reportMissingRequiredFlags = missingRequiredFlags => {
 	console.error(`Missing required flag${missingRequiredFlags.length > 1 ? 's' : ''}`);
 	for (const flag of missingRequiredFlags) {
-		console.error(`\t--${decamelize(flag.key, {separator: '-'})}${flag.alias ? `, -${flag.alias}` : ''}`);
+		console.error(`\t--${decamelize(flag.key, {separator: '-'})}${flag.shortFlag ? `, -${flag.shortFlag}` : ''}`);
 	}
 };
 
@@ -71,6 +71,12 @@ const buildParserFlags = ({flags, booleanDefault}) => {
 
 	for (const [flagKey, flagValue] of Object.entries(flags)) {
 		const flag = {...flagValue};
+
+		// `buildParserOptions` expects `flag.alias`
+		if (flag.shortFlag) {
+			flag.alias = flag.shortFlag;
+			delete flag.shortFlag;
+		}
 
 		if (
 			typeof booleanDefault !== 'undefined'
@@ -224,7 +230,7 @@ const meow = (helpText, options = {}) => {
 	validateFlags(flags, options);
 
 	for (const flagValue of Object.values(options.flags)) {
-		delete flags[flagValue.alias];
+		delete flags[flagValue.shortFlag];
 	}
 
 	const missingRequiredFlags = getMissingRequiredFlags(options.flags, flags, input);

--- a/index.js
+++ b/index.js
@@ -57,6 +57,11 @@ const validateOptions = ({flags}) => {
 	if (invalidFlags.length > 0) {
 		throw new Error(`Flag keys may not contain '-': ${invalidFlags.join(', ')}`);
 	}
+
+	const flagsWithAlias = Object.keys(flags).filter(flagKey => flags[flagKey].alias !== undefined);
+	if (flagsWithAlias.length > 0) {
+		throw new Error(`The option \`alias\` has been renamed to \`shortFlag\`. The following flags need to be updated: \`${flagsWithAlias.join('`, `')}\``);
+	}
 };
 
 const reportUnknownFlags = unknownFlags => {

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -52,7 +52,7 @@ expectType<Result<never>>(meow({importMeta, hardRejection: false}));
 const result = meow('Help text', {
 	importMeta,
 	flags: {
-		foo: {type: 'boolean', alias: 'f'},
+		foo: {type: 'boolean', shortFlag: 'f'},
 		'foo-bar': {type: 'number'},
 		bar: {type: 'string', default: ''},
 		abc: {type: 'string', isMultiple: true},
@@ -82,7 +82,7 @@ const options = {
 	flags: {
 		rainbow: {
 			type: 'boolean',
-			alias: 'r',
+			shortFlag: 'r',
 		},
 	},
 } as const;

--- a/readme.md
+++ b/readme.md
@@ -48,7 +48,7 @@ const cli = meow(`
 	flags: {
 		rainbow: {
 			type: 'boolean',
-			alias: 'r'
+			shortFlag: 'r'
 		}
 	}
 });
@@ -103,7 +103,7 @@ Define argument flags.
 The key is the flag name in camel-case and the value is an object with any of:
 
 - `type`: Type of value. (Possible values: `string` `boolean` `number`)
-- `alias`: Usually used to define a short flag alias.
+- `shortFlag`: A short flag alias.
 - `default`: Default value when the flag is not specified.
 - `isRequired`: Determine if the flag is required. (Default: false)
 	- If it's only known at runtime whether the flag is required or not, you can pass a `Function` instead of a `boolean`, which based on the given flags and other non-flag arguments, should decide if the flag is required. Two arguments are passed to the function:
@@ -121,7 +121,7 @@ Example:
 flags: {
 	unicorn: {
 		type: 'string',
-		alias: 'u',
+		shortFlag: 'u',
 		default: ['rainbow', 'cat'],
 		isMultiple: true,
 		isRequired: (flags, input) => {
@@ -242,16 +242,16 @@ const cli = meow(`
 		rainbow: {
 			type: 'boolean',
 			default: true,
-			alias: 'r'
+			shortFlag: 'r'
 		},
 		unicorn: {
 			type: 'boolean',
 			default: false,
-			alias: 'u'
+			shortFlag: 'u'
 		},
 		cake: {
 			type: 'boolean',
-			alias: 'c'
+			shortFlag: 'c'
 		},
 		sparkles: {
 			type: 'boolean',

--- a/test/fixtures/fixture-allow-unknown-flags-with-help.js
+++ b/test/fixtures/fixture-allow-unknown-flags-with-help.js
@@ -11,11 +11,11 @@ const cli = meow({
 	allowUnknownFlags: false,
 	flags: {
 		help: {
-			alias: 'h',
+			shortFlag: 'h',
 			type: 'boolean',
 		},
 		version: {
-			alias: 'v',
+			shortFlag: 'v',
 			type: 'boolean',
 		},
 	},

--- a/test/fixtures/fixture-conditional-required-multiple.js
+++ b/test/fixtures/fixture-conditional-required-multiple.js
@@ -11,7 +11,7 @@ const cli = meow({
 	flags: {
 		test: {
 			type: 'number',
-			alias: 't',
+			shortFlag: 't',
 			isRequired: () => false,
 			isMultiple: true,
 		},

--- a/test/fixtures/fixture-required-function.js
+++ b/test/fixtures/fixture-required-function.js
@@ -11,7 +11,7 @@ const cli = meow({
 	flags: {
 		trigger: {
 			type: 'boolean',
-			alias: 't',
+			shortFlag: 't',
 		},
 		withTrigger: {
 			type: 'string',
@@ -19,7 +19,7 @@ const cli = meow({
 		},
 		allowError: {
 			type: 'boolean',
-			alias: 'a',
+			shortFlag: 'a',
 		},
 		shouldError: {
 			type: 'boolean',

--- a/test/fixtures/fixture-required-multiple.js
+++ b/test/fixtures/fixture-required-multiple.js
@@ -11,7 +11,7 @@ const cli = meow({
 	flags: {
 		test: {
 			type: 'number',
-			alias: 't',
+			shortFlag: 't',
 			isRequired: true,
 			isMultiple: true,
 		},

--- a/test/fixtures/fixture-required.js
+++ b/test/fixtures/fixture-required.js
@@ -11,7 +11,7 @@ const cli = meow({
 	flags: {
 		test: {
 			type: 'string',
-			alias: 't',
+			shortFlag: 't',
 			isRequired: true,
 		},
 		number: {

--- a/test/fixtures/fixture.js
+++ b/test/fixtures/fixture.js
@@ -12,7 +12,7 @@ const cli = meow({
 	autoVersion: !process.argv.includes('--no-auto-version'),
 	autoHelp: !process.argv.includes('--no-auto-help'),
 	flags: {
-		unicorn: {alias: 'u'},
+		unicorn: {shortFlag: 'u'},
 		meow: {default: 'dog'},
 		camelCaseOption: {default: 'foo'},
 	},

--- a/test/test.js
+++ b/test/test.js
@@ -30,7 +30,7 @@ test('return object', t => {
 			  foo <input>
 		`,
 		flags: {
-			unicorn: {alias: 'u'},
+			unicorn: {shortFlag: 'u'},
 			meow: {default: 'dog'},
 			'--': true,
 		},
@@ -226,7 +226,7 @@ test('accept help and options', t => {
 		flags: {
 			foo: {
 				type: 'boolean',
-				alias: 'f',
+				shortFlag: 'f',
 			},
 		},
 	}).flags, {
@@ -241,11 +241,11 @@ test('grouped short-flags work', t => {
 		flags: {
 			coco: {
 				type: 'boolean',
-				alias: 'c',
+				shortFlag: 'c',
 			},
 			loco: {
 				type: 'boolean',
-				alias: 'l',
+				shortFlag: 'l',
 			},
 		},
 	});
@@ -264,11 +264,11 @@ test('grouped flags work', t => {
 		flags: {
 			coco: {
 				type: 'boolean',
-				alias: 'c',
+				shortFlag: 'c',
 			},
 			loco: {
 				type: 'boolean',
-				alias: 'l',
+				shortFlag: 'l',
 			},
 		},
 	});

--- a/test/test.js
+++ b/test/test.js
@@ -580,6 +580,28 @@ test('isMultiple - handles multi-word flag name', t => {
 	});
 });
 
+test('suggests renaming alias to shortFlag', t => {
+	t.throws(() => {
+		meow({
+			importMeta,
+			flags: {
+				foo: {
+					type: 'string',
+					alias: 'f',
+				},
+				bar: {
+					type: 'string',
+					alias: 'b',
+				},
+				baz: {
+					type: 'string',
+					shortFlag: 'z',
+				},
+			},
+		});
+	}, {message: 'The option `alias` has been renamed to `shortFlag`. The following flags need to be updated: `foo`, `bar`'});
+});
+
 if (NODE_MAJOR_VERSION >= 14) {
 	test('supports es modules', async t => {
 		try {


### PR DESCRIPTION
Closes #109.

`flag.alias` is now `flag.shortFlag` for users:

```js
const cli = meow(`
	Usage
	  $ foo <input>

	Options
	  --rainbow, -r  Include a rainbow

	Examples
	  $ foo unicorns --rainbow
	  🌈 unicorns 🌈
`, {
	importMeta: import.meta,
	flags: {
		rainbow: {
			type: 'boolean',
			shortFlag: 'r'
		}
	}
});
```

An extra check was added to `buildParserFlags()` to ensure compatibility with `minimist-options`:

```js
// index.js

const buildParserFlags = ({flags, booleanDefault}) => {
	const parserFlags = {};

	for (const [flagKey, flagValue] of Object.entries(flags)) {
		const flag = {...flagValue};

		// `buildParserOptions` expects `flag.alias`
		if (flag.shortFlag) {
			flag.alias = flag.shortFlag;
			delete flag.shortFlag;
		}

		// ...
	}

	return parserFlags;
}
```