### PR TITLE
Add `aliases` option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -48,7 +48,7 @@ export type Options<Flags extends AnyFlags> = {
 		If it's only known at runtime whether the flag is required or not you can pass a Function instead of a boolean, which based on the given flags and other non-flag arguments should decide if the flag is required.
 	- `isMultiple`: Indicates a flag can be set multiple times. Values are turned into an array. (Default: false)
 		Multiple values are provided by specifying the flag multiple times, for example, `$ foo -u rainbow -u cat`. Space- or comma-separated values are *not* supported.
-	- `aliases`: Other names for the flag. (Not a short flag)
+	- `aliases`: Other names for the flag.
 
 	Note that flags are always defined using a camel-case key (`myKey`), but will match arguments in kebab-case (`--my-key`).
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -21,6 +21,7 @@ export type Flag<Type extends FlagType, Default, IsMultiple = false> = {
 	readonly default?: Default;
 	readonly isRequired?: boolean | IsRequiredPredicate;
 	readonly isMultiple?: IsMultiple;
+	readonly aliases?: string[];
 };
 
 type StringFlag = Flag<'string', string> | Flag<'string', string[], true>;
@@ -47,6 +48,7 @@ export type Options<Flags extends AnyFlags> = {
 		If it's only known at runtime whether the flag is required or not you can pass a Function instead of a boolean, which based on the given flags and other non-flag arguments should decide if the flag is required.
 	- `isMultiple`: Indicates a flag can be set multiple times. Values are turned into an array. (Default: false)
 		Multiple values are provided by specifying the flag multiple times, for example, `$ foo -u rainbow -u cat`. Space- or comma-separated values are *not* supported.
+	- `aliases`: Other names for the flag. (Not a short flag)
 
 	Note that flags are always defined using a camel-case key (`myKey`), but will match arguments in kebab-case (`--my-key`).
 
@@ -64,7 +66,8 @@ export type Options<Flags extends AnyFlags> = {
 				}
 
 				return false;
-			}
+			},
+			aliases: ['unicorns']
 		}
 	}
 	```

--- a/index.js
+++ b/index.js
@@ -86,6 +86,15 @@ const buildParserFlags = ({flags, booleanDefault}) => {
 			delete flag.isMultiple;
 		}
 
+		if (Array.isArray(flag.aliases)) {
+			if (flag.alias) {
+				flag.aliases.push(flag.alias);
+			}
+
+			flag.alias = flag.aliases;
+			delete flag.aliases;
+		}
+
 		parserFlags[flagKey] = flag;
 	}
 
@@ -224,6 +233,12 @@ const meow = (helpText, options = {}) => {
 	validateFlags(flags, options);
 
 	for (const flagValue of Object.values(options.flags)) {
+		if (Array.isArray(flagValue.aliases)) {
+			for (const alias of flagValue.aliases) {
+				delete flags[alias];
+			}
+		}
+
 		delete flags[flagValue.alias];
 	}
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -53,7 +53,7 @@ const result = meow('Help text', {
 	importMeta,
 	flags: {
 		foo: {type: 'boolean', alias: 'f'},
-		'foo-bar': {type: 'number'},
+		'foo-bar': {type: 'number', aliases: ['foobar', 'fooBar']},
 		bar: {type: 'string', default: ''},
 		abc: {type: 'string', isMultiple: true},
 	},
@@ -70,6 +70,8 @@ expectType<string[] | undefined>(result.flags.abc);
 expectType<boolean | undefined>(result.unnormalizedFlags.foo);
 expectType<unknown>(result.unnormalizedFlags.f);
 expectType<number | undefined>(result.unnormalizedFlags['foo-bar']);
+expectType<unknown>(result.unnormalizedFlags.foobar);
+expectType<unknown>(result.unnormalizedFlags.fooBar);
 expectType<string>(result.unnormalizedFlags.bar);
 expectType<string[] | undefined>(result.unnormalizedFlags.abc);
 

--- a/readme.md
+++ b/readme.md
@@ -112,6 +112,7 @@ The key is the flag name in camel-case and the value is an object with any of:
 	- The function should return a `boolean`, true if the flag is required, otherwise false.
 - `isMultiple`: Indicates a flag can be set multiple times. Values are turned into an array. (Default: false)
 	- Multiple values are provided by specifying the flag multiple times, for example, `$ foo -u rainbow -u cat`. Space- or comma-separated values are [currently *not* supported](https://github.com/sindresorhus/meow/issues/164).
+- `aliases`: Other names for the flag. (Not a short flag)
 
 Note that flags are always defined using a camel-case key (`myKey`), but will match arguments in kebab-case (`--my-key`).
 
@@ -130,7 +131,8 @@ flags: {
 			}
 
 			return false;
-		}
+		},
+		aliases: ['unicorns']
 	}
 }
 ```

--- a/readme.md
+++ b/readme.md
@@ -112,7 +112,7 @@ The key is the flag name in camel-case and the value is an object with any of:
 	- The function should return a `boolean`, true if the flag is required, otherwise false.
 - `isMultiple`: Indicates a flag can be set multiple times. Values are turned into an array. (Default: false)
 	- Multiple values are provided by specifying the flag multiple times, for example, `$ foo -u rainbow -u cat`. Space- or comma-separated values are [currently *not* supported](https://github.com/sindresorhus/meow/issues/164).
-- `aliases`: Other names for the flag. (Not a short flag)
+- `aliases`: Other names for the flag.
 
 Note that flags are always defined using a camel-case key (`myKey`), but will match arguments in kebab-case (`--my-key`).
 

--- a/test/test.js
+++ b/test/test.js
@@ -633,6 +633,21 @@ test('aliases - accepts multiple', t => {
 	});
 });
 
+test('aliases - can be a short flag', t => {
+	t.deepEqual(meow({
+		importMeta,
+		argv: ['--f=baz'],
+		flags: {
+			fooBar: {
+				type: 'string',
+				aliases: ['f'],
+			},
+		},
+	}).flags, {
+		fooBar: 'baz',
+	});
+});
+
 test('aliases - works with short flag', t => {
 	t.deepEqual(meow({
 		importMeta,

--- a/test/test.js
+++ b/test/test.js
@@ -580,6 +580,54 @@ test('isMultiple - handles multi-word flag name', t => {
 	});
 });
 
+test('aliases - accepts one', t => {
+	t.deepEqual(meow({
+		importMeta,
+		argv: ['--foo=baz'],
+		flags: {
+			fooBar: {
+				type: 'string',
+				aliases: ['foo'],
+			},
+		},
+	}).flags, {
+		fooBar: 'baz',
+	});
+});
+
+test('aliases - accepts multiple', t => {
+	t.deepEqual(meow({
+		importMeta,
+		argv: ['--foo=baz1', '--bar=baz2'],
+		flags: {
+			fooBar: {
+				type: 'string',
+				aliases: ['foo', 'bar'],
+				isMultiple: true,
+			},
+		},
+	}).flags, {
+		fooBar: ['baz1', 'baz2'],
+	});
+});
+
+test('aliases - works with short flag alias', t => {
+	t.deepEqual(meow({
+		importMeta,
+		argv: ['--foo=baz1', '--bar=baz2', '-f=baz3'],
+		flags: {
+			fooBar: {
+				type: 'string',
+				alias: 'f',
+				aliases: ['foo', 'bar'],
+				isMultiple: true,
+			},
+		},
+	}).flags, {
+		fooBar: ['baz1', 'baz2', 'baz3'],
+	});
+});
+
 if (NODE_MAJOR_VERSION >= 14) {
 	test('supports es modules', async t => {
 		try {

--- a/test/test.js
+++ b/test/test.js
@@ -633,14 +633,14 @@ test('aliases - accepts multiple', t => {
 	});
 });
 
-test('aliases - works with short flag alias', t => {
+test('aliases - works with short flag', t => {
 	t.deepEqual(meow({
 		importMeta,
 		argv: ['--foo=baz1', '--bar=baz2', '-f=baz3'],
 		flags: {
 			fooBar: {
 				type: 'string',
-				alias: 'f',
+				shortFlag: 'f',
 				aliases: ['foo', 'bar'],
 				isMultiple: true,
 			},


### PR DESCRIPTION
Adds `flag.aliases` as specified in #109:

```js
flags: {
	unicorn: {
		type: 'string',
		shortFlag: 'u',
		aliases: ['unicorns']
	}
}
//=> Accepts `--unicorn`, `--unicorns`, or `-u`
```