### PR TITLE
Add test for `unnormalizedFlags` with `aliases`

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -665,6 +665,24 @@ test('aliases - works with short flag', t => {
 	});
 });
 
+test('aliases - unnormalized flags', t => {
+	t.deepEqual(meow({
+		importMeta,
+		argv: ['--foo=baz'],
+		flags: {
+			fooBar: {
+				type: 'string',
+				aliases: ['foo'],
+				shortFlag: 'f',
+			},
+		},
+	}).unnormalizedFlags, {
+		fooBar: 'baz',
+		foo: 'baz',
+		f: 'baz',
+	});
+});
+
 if (NODE_MAJOR_VERSION >= 14) {
 	test('supports es modules', async t => {
 		try {


### PR DESCRIPTION
Adds a test case to make sure that `cli.unnormalizedFlags` works correctly with the new `aliases` option:

```js
test('aliases - unnormalized flags', t => {
	t.deepEqual(meow({
		importMeta,
		argv: ['--foo=baz'],
		flags: {
			fooBar: {
				type: 'string',
				aliases: ['foo'],
				shortFlag: 'f',
			},
		},
	}).unnormalizedFlags, {
		fooBar: 'baz',
		foo: 'baz',
		f: 'baz',
	});
});
```