### PR TITLE
Provide JSDoc comments for flag properties

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -40,7 +40,7 @@ export type Flag<PrimitiveType extends FlagType, Type, IsMultiple = false> = {
 	```
 	unicorn: {
 		type: 'boolean',
-		default: true,
+		default: true
 	}
 	```
 	*/
@@ -94,7 +94,7 @@ export type Flag<PrimitiveType extends FlagType, Type, IsMultiple = false> = {
 	```
 	unicorn: {
 		isMultiple: true,
-		choices: ['rainbow', 'cat', 'unicorn'],
+		choices: ['rainbow', 'cat', 'unicorn']
 	}
 	```
 	*/

--- a/index.d.ts
+++ b/index.d.ts
@@ -81,7 +81,7 @@ export type Flag<Type extends FlagType, Default, IsMultiple = false> = {
 	@example
 	```
 	unicorn: {
-		aliases: ['unicorns', 'u']
+		aliases: ['unicorns', 'uni']
 	}
 	```
 	*/

--- a/index.d.ts
+++ b/index.d.ts
@@ -86,6 +86,18 @@ export type Flag<PrimitiveType extends FlagType, Type, IsMultiple = false> = {
 	```
 	*/
 	readonly aliases?: string[];
+
+	/**
+	Limit valid values to a predefined set of choices.
+
+	@example
+	```
+	unicorn: {
+		isMultiple: true,
+		choices: ['rainbow', 'cat', 'unicorn'],
+	}
+	```
+	*/
 	readonly choices?: Type extends unknown[] ? Type : Type[];
 };
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -16,11 +16,75 @@ Callback function to determine if a flag is required during runtime.
 export type IsRequiredPredicate = (flags: Readonly<AnyFlags>, input: readonly string[]) => boolean;
 
 export type Flag<Type extends FlagType, Default, IsMultiple = false> = {
+	/**
+	Type of value. (Possible values: `string` `boolean` `number`)
+	*/
 	readonly type?: Type;
+
+	/**
+	A short flag alias.
+
+	@example
+	```
+	unicorn: {
+		shortFlag: 'u'
+	}
+	```
+	*/
 	readonly shortFlag?: string;
+
+	/**
+	Default value when the flag is not specified.
+
+	@example
+	```
+	unicorn: {
+		type: 'boolean',
+		default: true,
+	}
+	```
+	*/
 	readonly default?: Default;
+
+	/**
+	Determine if the flag is required.
+
+	If it's only known at runtime whether the flag is required or not you can pass a Function instead of a boolean, which based on the given flags and other non-flag arguments should decide if the flag is required.
+
+	@default false
+
+	@example
+	```
+	isRequired: (flags, input) => {
+		if (flags.otherFlag) {
+			return true;
+		}
+
+		return false;
+	}
+	```
+	*/
 	readonly isRequired?: boolean | IsRequiredPredicate;
+
+	/**
+	Indicates a flag can be set multiple times. Values are turned into an array.
+
+	Multiple values are provided by specifying the flag multiple times, for example, `$ foo -u rainbow -u cat`. Space- or comma-separated values are *not* supported.
+
+	@default false
+	*/
 	readonly isMultiple?: IsMultiple;
+
+	/**
+	Other names for the flag.
+
+	@example
+	```
+	unicorn: {
+		aliases: ['unicorns', 'u']
+	}
+	```
+	*/
 	readonly aliases?: string[];
 };
 

--- a/readme.md
+++ b/readme.md
@@ -103,17 +103,17 @@ Define argument flags.
 The key is the flag name in camel-case and the value is an object with any of:
 
 - `type`: Type of value. (Possible values: `string` `boolean` `number`)
-- `shortFlag`: A short flag alias.
+- `choices`: Limit valid values to a predefined set of choices.
 - `default`: Default value when the flag is not specified.
+- `shortFlag`: A short flag alias.
+- `aliases`: Other names for the flag.
+- `isMultiple`: Indicates a flag can be set multiple times. Values are turned into an array. (Default: false)
+	- Multiple values are provided by specifying the flag multiple times, for example, `$ foo -u rainbow -u cat`. Space- or comma-separated values are [currently *not* supported](https://github.com/sindresorhus/meow/issues/164).
 - `isRequired`: Determine if the flag is required. (Default: false)
 	- If it's only known at runtime whether the flag is required or not, you can pass a `Function` instead of a `boolean`, which based on the given flags and other non-flag arguments, should decide if the flag is required. Two arguments are passed to the function:
 	- The first argument is the **flags** object, which contains the flags converted to camel-case excluding aliases.
 	- The second argument is the **input** string array, which contains the non-flag arguments.
 	- The function should return a `boolean`, true if the flag is required, otherwise false.
-- `isMultiple`: Indicates a flag can be set multiple times. Values are turned into an array. (Default: false)
-	- Multiple values are provided by specifying the flag multiple times, for example, `$ foo -u rainbow -u cat`. Space- or comma-separated values are [currently *not* supported](https://github.com/sindresorhus/meow/issues/164).
-- `aliases`: Other names for the flag.
-- `choices`: Limit valid values to a predefined set of choices.
 
 Note that flags are always defined using a camel-case key (`myKey`), but will match arguments in kebab-case (`--my-key`).
 
@@ -123,18 +123,18 @@ Example:
 flags: {
 	unicorn: {
 		type: 'string',
-		shortFlag: 'u',
-		default: ['rainbow', 'cat'],
-		isMultiple: true,
 		choices: ['rainbow', 'cat', 'unicorn'],
+		default: ['rainbow', 'cat'],
+		shortFlag: 'u',
+		aliases: ['unicorns'],
+		isMultiple: true,
 		isRequired: (flags, input) => {
 			if (flags.otherFlag) {
 				return true;
 			}
 
 			return false;
-		},
-		aliases: ['unicorns']
+		}
 	}
 }
 ```


### PR DESCRIPTION
Adds JSDoc comments to each property of the type `Flag` so that Intellisense is provided when creating a flag:

<img width="878" alt="image" src="https://user-images.githubusercontent.com/1403701/227594339-ea2eb454-e436-4b5e-b29b-cbb3ba606657.png">
