### PR TITLE
Don't indent single line `help` / `description` text

### DIFF
--- a/index.js
+++ b/index.js
@@ -284,7 +284,11 @@ const meow = (helpText, options = {}) => {
 
 	const {pkg: package_} = options;
 	const argv = parseArguments(options.argv, parserOptions);
-	let help = redent(trimNewlines((options.help ?? '').replace(/\t+\n*$/, '')), 2);
+	let help = trimNewlines((options.help || '').replace(/\t+\n*$/, ''));
+
+	if (help.includes('\n')) {
+		help = redent(help, 2);
+	}
 
 	normalizePackageData(package_);
 
@@ -295,7 +299,12 @@ const meow = (helpText, options = {}) => {
 		({description} = package_);
 	}
 
-	help = (description ? `\n  ${description}\n` : '') + (help ? `\n${help}\n` : '\n');
+	// Change to `&&=` when targeting Node 15+
+	if (description) {
+		description = help ? `\n  ${description}\n` : `\n${description}`;
+	}
+
+	help = (description || '') + (help ? `\n${help}\n` : '\n');
 
 	const showHelp = code => {
 		console.log(help);

--- a/test/test.js
+++ b/test/test.js
@@ -897,6 +897,26 @@ test('options - multiple validation errors', t => {
 	`});
 });
 
+test('single line help messages are not indented', t => {
+	const cli = meow({
+		importMeta,
+		description: false,
+		help: 'single line',
+	});
+
+	t.is(cli.help, '\nsingle line\n');
+});
+
+test('descriptions with no help are not indented', t => {
+	const cli = meow({
+		importMeta,
+		help: false,
+		description: 'single line',
+	});
+
+	t.is(cli.help, '\nsingle line\n');
+});
+
 if (NODE_MAJOR_VERSION >= 14) {
 	test('supports es modules', async t => {
 		try {


### PR DESCRIPTION
Closes #229.

If `help` has no newlines and if `description` is false, or if `description` is set and `help` is false, don't indent the message:

```
$ my-command

Single-line usage info or description.

```