### PR TITLE
Fix flag.default values validation

### DIFF
--- a/source/options.js
+++ b/source/options.js
@@ -27,7 +27,7 @@ const validateOptions = options => {
 				},
 			},
 			defaultNotInChoices: {
-				filter: ([, flag]) => flag.default && Array.isArray(flag.choices) && [flag.default].flat().every(value => flag.choices.includes(value)),
+				filter: ([, flag]) => flag.default && Array.isArray(flag.choices) && ![flag.default].flat().every(value => flag.choices.includes(value)),
 				message: flagKeys => `Each value of the option \`default\` must exist within the option \`choices\`. Invalid flags: ${joinFlagKeys(flagKeys)}`,
 			},
 		},

--- a/test/choices.js
+++ b/test/choices.js
@@ -177,8 +177,8 @@ test('choices - choices must be of the same type', t => {
 	}, {message: 'Each value of the option `choices` must be of the same type as its flag. Invalid flags: (`--number`, type: \'number\'), (`--boolean`, type: \'boolean\')'});
 });
 
-test('choices - default must only include valid choices', t => {
-	t.throws(() => {
+test('choices - success when each value of default exist within the option choices', t => {
+	t.notThrows(() => {
 		meow({
 			importMeta,
 			flags: {
@@ -187,7 +187,44 @@ test('choices - default must only include valid choices', t => {
 					choices: [1, 2, 3],
 					default: 1,
 				},
+				string: {
+					type: 'string',
+					choices: ['dog', 'cat', 'unicorn'],
+					default: 'dog',
+				},
+				multiString: {
+					type: 'string',
+					choices: ['dog', 'cat', 'unicorn'],
+					default: ['dog', 'cat'],
+					isMultiple: true,
+				},
 			},
 		});
-	}, {message: 'Each value of the option `default` must exist within the option `choices`. Invalid flags: `--number`'});
+	});
+});
+
+test('choices - throws when default does not only include valid choices', t => {
+	t.throws(() => {
+		meow({
+			importMeta,
+			flags: {
+				number: {
+					type: 'number',
+					choices: [1, 2, 3],
+					default: 8,
+				},
+				string: {
+					type: 'string',
+					choices: ['dog', 'cat'],
+					default: 'unicorn',
+				},
+				multiString: {
+					type: 'string',
+					choices: ['dog', 'cat'],
+					default: ['dog', 'unicorn'],
+					isMultiple: true,
+				},
+			},
+		});
+	}, {message: 'Each value of the option `default` must exist within the option `choices`. Invalid flags: `--number`, `--string`, `--multiString`'});
 });


### PR DESCRIPTION
Fixes #239
This fixes the validation of the default values.

Example:
```
meow({
	importMeta,
	flags: {
		string: {
			type: 'string',
			choices: ['dog', 'cat', 'unicorn'],
			default: 'unicorn',
		},
	},
});
```
should not throw an error, since 'unicorn' exists within the option `choices`.

But instead, it throws the following error:
```
Each value of the option `default` must exist within the option `choices`. Invalid flags: `--string`.
```