### PR TITLE
fix: use default types location to comply legacy tsc moduleResolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,10 +11,8 @@
 		"url": "https://sindresorhus.com"
 	},
 	"type": "module",
-	"exports": {
-		"types": "./build/index.d.ts",
-		"default": "./build/index.js"
-	},
+	"types": "./build/index.d.ts",
+	"exports": "./build/index.js",
 	"sideEffects": false,
 	"engines": {
 		"node": ">=16.10"


### PR DESCRIPTION
12.1.1 brings a new types location, which differs from the default `./index.d.ts`, so now it breaks transpilation for many _legacy_ tsconfigs. Let's keep it compatible.

https://github.com/microsoft/TypeScript/issues/51862