### PR TITLE
add `types` to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
 		"types": "./build/index.d.ts",
 		"default": "./build/index.js"
 	},
+	"types": "./build/index.d.ts",
 	"sideEffects": false,
 	"engines": {
 		"node": ">=18"


### PR DESCRIPTION
I'm surprised this is needed, but it seems to be. Types are not being inferred with just the `exports.types` field. This seems to be the case on npmjs.com, in VSCode, and via the typescript compiler.

Adding `types` seems to fix.

A few ways to see it's not right at the moment:

[Demo in typescript playground](https://www.typescriptlang.org/play?#code/JYWwDg9gTgLgBCAphA7nAZlCI4HImq4BQRoksCyKAkgHYyJS0CGANhljvlQPQBGAV2CsAJj2C0RiAB4A6AFYBnYkA) (note that if you reach into the package via `import meow from 'meow/build/index.js'`, you do get the correct types 🤷.

[Are The Types Wrong result](https://arethetypeswrong.github.io/?p=meow%4013.1.0)

[`DT` icon on npmjs.com](https://www.npmjs.com/package/meow/v/13.1.0):

<img width="695" alt="image" src="https://github.com/sindresorhus/meow/assets/15040698/87cab6e9-2147-4860-9e5e-448d014d66bc">
