### PR TITLE
Clean up `description` parsing

### DIFF
--- a/source/options.js
+++ b/source/options.js
@@ -2,6 +2,7 @@ import process from 'node:process';
 import {dirname} from 'node:path';
 import {fileURLToPath} from 'node:url';
 import {readPackageUpSync} from 'read-package-up';
+import normalizePackageData from 'normalize-package-data';
 import {decamelizeFlagKey, joinFlagKeys} from './utils.js';
 
 const validateOptions = options => {
@@ -63,17 +64,21 @@ export const buildOptions = (helpText, options) => {
 		throw new TypeError('The `importMeta` option is required. Its value must be `import.meta`.');
 	}
 
-	const foundPackage = readPackageUpSync({
+	const foundPackage = options.pkg ?? readPackageUpSync({
 		cwd: dirname(fileURLToPath(options.importMeta.url)),
 		normalize: false,
-	});
+	})?.packageJson;
+
+	// eslint-disable-next-line unicorn/prevent-abbreviations
+	const pkg = foundPackage ?? {};
+	normalizePackageData(pkg);
 
 	const parsedOptions = {
-		pkg: foundPackage ? foundPackage.packageJson : {},
 		argv: process.argv.slice(2),
 		flags: {},
 		inferType: false,
 		input: 'string',
+		description: pkg.description ?? false,
 		help: helpText,
 		autoHelp: true,
 		autoVersion: true,
@@ -82,6 +87,7 @@ export const buildOptions = (helpText, options) => {
 		allowParentFlags: true,
 		helpIndent: 2,
 		...options,
+		pkg,
 	};
 
 	validateOptions(parsedOptions);

--- a/test/options/help.js
+++ b/test/options/help.js
@@ -25,12 +25,25 @@ test('support help shortcut', verifyHelp, {
 		unicorn
 		cat
 	`],
-	expected: indentString('\nCLI app helper\n\nunicorn\ncat\n', 2),
+	expected: indentString(stripIndent`
+
+		CLI app helper
+
+		unicorn
+		cat
+	`, 2),
 });
 
 test('spawn cli and show help screen', verifyCli, {
 	args: '--help',
-	expected: indentString('\nCustom description\n\nUsage\n  foo <input>\n\n', 2),
+	expected: indentString(stripIndent`
+
+		Custom description
+
+		Usage
+		  foo <input>
+
+	`, 2),
 });
 
 test('spawn cli and disabled autoHelp', verifyCli, {


### PR DESCRIPTION
Separating out from #252.

Probably shouldn't have written this to begin with:

```js
description &&= help ? redent(`\n${description}\n`, options.helpIndent) : `\n${description}`;
help = `${description || ''}${help}\n`;
```