### PR TITLE
Remove `null` from `booleanDefault` type

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -213,7 +213,7 @@ By default, the argument `5` in `$ foo 5` becomes a string. Enabling this would 
 
 ##### booleanDefault
 
-Type: `boolean | null | undefined`\
+Type: `boolean | undefined`\
 Default: `false`
 
 Value of `boolean` flags not defined in `argv`.

--- a/source/index.d.ts
+++ b/source/index.d.ts
@@ -291,8 +291,7 @@ export type Options<Flags extends AnyFlags> = {
 	//}
 	```
 	*/
-	// eslint-disable-next-line @typescript-eslint/ban-types
-	readonly booleanDefault?: boolean | null | undefined;
+	readonly booleanDefault?: boolean | undefined;
 
 	// TODO: Remove this in meow 14.
 	/**

--- a/source/parser.js
+++ b/source/parser.js
@@ -13,11 +13,7 @@ const buildParserFlags = ({flags, booleanDefault}) => {
 			delete flag.shortFlag;
 		}
 
-		if (
-			booleanDefault !== undefined
-				&& flag.type === 'boolean'
-				&& !Object.hasOwn(flag, 'default')
-		) {
+		if (booleanDefault !== undefined && flag.type === 'boolean' && !Object.hasOwn(flag, 'default')) {
 			flag.default = flag.isMultiple ? [booleanDefault] : booleanDefault;
 		}
 

--- a/test-d/build.test-d.ts
+++ b/test-d/build.test-d.ts
@@ -47,7 +47,6 @@ expectType<Result<never>>(meow({importMeta, pkg: {foo: 'bar'}}));
 expectType<Result<never>>(meow({importMeta, argv: ['foo', 'bar']}));
 expectType<Result<never>>(meow({importMeta, inferType: true}));
 expectType<Result<never>>(meow({importMeta, booleanDefault: true}));
-expectType<Result<never>>(meow({importMeta, booleanDefault: null}));
 expectType<Result<never>>(meow({importMeta, booleanDefault: undefined}));
 expectType<Result<never>>(meow({importMeta}));
 

--- a/test-d/index.test-d.ts
+++ b/test-d/index.test-d.ts
@@ -47,7 +47,6 @@ expectType<Result<never>>(meow({importMeta, pkg: {foo: 'bar'}}));
 expectType<Result<never>>(meow({importMeta, argv: ['foo', 'bar']}));
 expectType<Result<never>>(meow({importMeta, inferType: true}));
 expectType<Result<never>>(meow({importMeta, booleanDefault: true}));
-expectType<Result<never>>(meow({importMeta, booleanDefault: null}));
 expectType<Result<never>>(meow({importMeta, booleanDefault: undefined}));
 expectType<Result<never>>(meow({importMeta, hardRejection: false}));
 

--- a/test/flags/_utils.js
+++ b/test/flags/_utils.js
@@ -2,10 +2,16 @@
 import test from 'ava';
 import meow from '../../source/index.js';
 
-export const _verifyFlags = importMeta => test.macro(async (t, {flags = {}, args, expected, error}) => {
+export const _verifyFlags = importMeta => test.macro(async (t, {flags = {}, args, expected, error, ...meowOptions}) => {
 	const assertions = await t.try(async tt => {
 		const arguments_ = args?.split(' ') ?? [];
-		const meowOptions = {importMeta, argv: arguments_, flags};
+
+		meowOptions = {
+			...meowOptions,
+			importMeta,
+			argv: arguments_,
+			flags,
+		};
 
 		tt.log('arguments:', arguments_);
 

--- a/test/flags/boolean-default.js
+++ b/test/flags/boolean-default.js
@@ -1,55 +1,58 @@
 import test from 'ava';
-import meow from '../../source/index.js';
+import {_verifyFlags} from './_utils.js';
 
-const importMeta = import.meta;
+const verifyFlags = _verifyFlags(import.meta);
 
-test('undefined - filter out unset boolean args', t => {
-	const cli = meow({
-		importMeta,
-		argv: ['--foo'],
-		booleanDefault: undefined,
-		flags: {
-			foo: {
-				type: 'boolean',
-			},
-			bar: {
-				type: 'boolean',
-			},
-			baz: {
-				type: 'boolean',
-				default: false,
-			},
+test('undefined - filter out unset boolean args', verifyFlags, {
+	booleanDefault: undefined,
+	flags: {
+		foo: {
+			type: 'boolean',
 		},
-	});
-
-	t.like(cli.flags, {
+		bar: {
+			type: 'boolean',
+		},
+		baz: {
+			type: 'boolean',
+			default: false,
+		},
+	},
+	args: '--foo',
+	expected: {
 		foo: true,
 		bar: undefined,
 		baz: false,
-	});
+	},
 });
 
-test('boolean args are false by default', t => {
-	const cli = meow({
-		importMeta,
-		argv: ['--foo'],
-		flags: {
-			foo: {
-				type: 'boolean',
-			},
-			bar: {
-				type: 'boolean',
-				default: true,
-			},
-			baz: {
-				type: 'boolean',
-			},
+test('boolean args are false by default', verifyFlags, {
+	flags: {
+		foo: {
+			type: 'boolean',
 		},
-	});
-
-	t.like(cli.flags, {
+		bar: {
+			type: 'boolean',
+			default: true,
+		},
+		baz: {
+			type: 'boolean',
+		},
+	},
+	args: '--foo',
+	expected: {
 		foo: true,
 		bar: true,
 		baz: false,
-	});
+	},
+});
+
+test('throws if default is null', verifyFlags, {
+	booleanDefault: null,
+	flags: {
+		foo: {
+			type: 'boolean',
+		},
+	},
+	args: '--foo',
+	error: 'Expected "foo" default value to be of type "boolean", got "null"',
 });


### PR DESCRIPTION
* this was introduced in #77, likely due to compatibility with minimist
* `booleanDefault: null` causes minimist-options to error
* even in 2019, this was a confusing type: https://github.com/sindresorhus/meow/pull/116#discussion_r265863719

---

Split out from #252.