### PR TITLE
Remove `false` from `version` type, add fallback message

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -161,7 +161,7 @@ The description will be shown above your help text automatically.
 
 ##### version
 
-Type: `string | boolean`\
+Type: `string`\
 Default: The package.json `"version"` property
 
 Set a custom version output.

--- a/source/index.d.ts
+++ b/source/index.d.ts
@@ -180,10 +180,8 @@ export type Options<Flags extends AnyFlags> = {
 
 	/**
 	Set a custom version output. Default: The package.json `"version"` property.
-
-	Set it to `false` to disable it altogether.
 	*/
-	readonly version?: string | false;
+	readonly version?: string;
 
 	/**
 	Automatically show the help text when the `--help` flag is present. Useful to set this value to `false` when a CLI manages child CLIs with their own help text.

--- a/source/index.js
+++ b/source/index.js
@@ -36,7 +36,7 @@ const buildResult = (options, parserOptions) => {
 	};
 
 	const showVersion = () => {
-		console.log(typeof options.version === 'string' ? options.version : package_.version);
+		console.log(options.version);
 		process.exit(0);
 	};
 

--- a/source/options.js
+++ b/source/options.js
@@ -75,6 +75,7 @@ export const buildOptions = (helpText, options) => {
 		inferType: false,
 		input: 'string',
 		help: helpText,
+		version: foundPackage?.packageJson.version || 'No version found',
 		autoHelp: true,
 		autoVersion: true,
 		booleanDefault: false,

--- a/test-d/build.test-d.ts
+++ b/test-d/build.test-d.ts
@@ -40,7 +40,6 @@ expectType<Result<never>>(meow({importMeta, description: false}));
 expectType<Result<never>>(meow({importMeta, help: 'foo'}));
 expectType<Result<never>>(meow({importMeta, help: false}));
 expectType<Result<never>>(meow({importMeta, version: 'foo'}));
-expectType<Result<never>>(meow({importMeta, version: false}));
 expectType<Result<never>>(meow({importMeta, autoHelp: false}));
 expectType<Result<never>>(meow({importMeta, autoVersion: false}));
 expectType<Result<never>>(meow({importMeta, pkg: {foo: 'bar'}}));

--- a/test-d/index.test-d.ts
+++ b/test-d/index.test-d.ts
@@ -40,7 +40,6 @@ expectType<Result<never>>(meow({importMeta, description: false}));
 expectType<Result<never>>(meow({importMeta, help: 'foo'}));
 expectType<Result<never>>(meow({importMeta, help: false}));
 expectType<Result<never>>(meow({importMeta, version: 'foo'}));
-expectType<Result<never>>(meow({importMeta, version: false}));
 expectType<Result<never>>(meow({importMeta, autoHelp: false}));
 expectType<Result<never>>(meow({importMeta, autoVersion: false}));
 expectType<Result<never>>(meow({importMeta, pkg: {foo: 'bar'}}));

--- a/test/options/version.js
+++ b/test/options/version.js
@@ -38,7 +38,7 @@ test('custom version', verifyVersion, {
 test('version = false has no effect', verifyVersion, {
 	args: '--version',
 	execaOptions: {env: {VERSION: 'false'}},
-	expected: '1.0.0',
+	expected: 'false',
 });
 
 test('manual showVersion', verifyVersion, {

--- a/test/options/version.js
+++ b/test/options/version.js
@@ -45,3 +45,9 @@ test('manual showVersion', verifyVersion, {
 	args: '--show-version',
 	expected: '1.0.0',
 });
+
+test('no version fallback message', verifyVersion, {
+	fixture: 'with-package-json/default/fixture.js',
+	args: '--version',
+	expected: 'No version found',
+});


### PR DESCRIPTION
`false` has had no effect since #68.

---

Splitting out from #252 (ref: https://github.com/sindresorhus/meow/pull/252#discussion_r1468905743).